### PR TITLE
Remove Vivaldi

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1307,7 +1307,7 @@ Add the following commands to a search to manually scrape each site.
 
 **Multi-Platform**
 
-[Vivaldi](https://vivaldi.com/), [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium), [Librewolf](https://gitlab.com/librewolf-community/browser/windows), [Librewolf Linux](https://librewolf-community.gitlab.io/), [Librefox](https://github.com/intika/Librefox/), [Netsurf](https://www.netsurf-browser.org/), [Wexond](https://github.com/wexond/desktop), [Dot](https://github.com/dothq/browser) (Linux / Alpha), [Otter](https://otter-browser.org/), [BadWolf](https://hacktivis.me/projects/badwolf), [Sphere](https://sphere.tenebris.cc/), [dumb-browser](https://github.com/f32by/dumb-browser), [Breeze](https://github.com/privacyone/breeze-core), [Dot HQ](https://www.dothq.co/) / [Discord](https://invite.gg/dot), [Viper-Browser](https://github.com/LeFroid/Viper-Browser)
+[Tor Browser (Safest)](https://www.torproject.org), [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium), [Librewolf](https://gitlab.com/librewolf-community/browser/windows), [Librewolf Linux](https://librewolf-community.gitlab.io/), [Librefox](https://github.com/intika/Librefox/), [Netsurf](https://www.netsurf-browser.org/), [Wexond](https://github.com/wexond/desktop), [Dot](https://github.com/dothq/browser) (Linux / Alpha), [Otter](https://otter-browser.org/), [BadWolf](https://hacktivis.me/projects/badwolf), [Sphere](https://sphere.tenebris.cc/), [dumb-browser](https://github.com/f32by/dumb-browser), [Breeze](https://github.com/privacyone/breeze-core), [Dot HQ](https://www.dothq.co/) / [Discord](https://invite.gg/dot), [Viper-Browser](https://github.com/LeFroid/Viper-Browser)
 
 **Android**
 


### PR DESCRIPTION
Vivaldi is a closed source unsafe browser, Even if you don't care about "Open Source", It's more important to have browsers that are safe such as Tor Browser in the beginning, Vivaldi offers nothing that makes it secure and "Private", The company actively tries to shut down any and all reverse engineering of the bad chromium skin and the code is shut down behind doors, Tor Browser on the other hand, Its source is free for public consumption, anyone can edit it as they please, and bugs can be fixed faster (if found), and just as an added bonus the browser actually masks your IP.