### PR TITLE
Removal of Ungoogled-Chromium and addition of Brave

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1516,7 +1516,7 @@ Add the following commands to a search to manually scrape each site.
 
 **Multi-Platform**
 
-[Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium), [Librewolf](https://gitlab.com/librewolf-community/browser/windows), [Librefox](https://github.com/intika/Librefox/), [Netsurf](https://www.netsurf-browser.org/), [Wexond](https://github.com/wexond/desktop), [Otter](https://otter-browser.org/), [BadWolf](https://hacktivis.me/projects/badwolf), [Sphere](https://sphere.tenebris.cc/), [dumb-browser](https://github.com/f32by/dumb-browser), [Breeze](https://github.com/privacyone/breeze-core), [Dot HQ](https://www.dothq.co/) / [Discord](https://invite.gg/dot), [Viper-Browser](https://github.com/LeFroid/Viper-Browser)
+[Brave] (https://brave.com), [Librewolf](https://gitlab.com/librewolf-community/browser/windows), [Librefox](https://github.com/intika/Librefox/), [Netsurf](https://www.netsurf-browser.org/), [Wexond](https://github.com/wexond/desktop), [Otter](https://otter-browser.org/), [BadWolf](https://hacktivis.me/projects/badwolf), [Sphere](https://sphere.tenebris.cc/), [dumb-browser](https://github.com/f32by/dumb-browser), [Breeze](https://github.com/privacyone/breeze-core), [Dot HQ](https://www.dothq.co/) / [Discord](https://invite.gg/dot), [Viper-Browser](https://github.com/LeFroid/Viper-Browser)
 
 **Android**
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1516,7 +1516,7 @@ Add the following commands to a search to manually scrape each site.
 
 **Multi-Platform**
 
-[Brave] (https://brave.com), [Librewolf](https://gitlab.com/librewolf-community/browser/windows), [Librefox](https://github.com/intika/Librefox/), [Netsurf](https://www.netsurf-browser.org/), [Wexond](https://github.com/wexond/desktop), [Otter](https://otter-browser.org/), [BadWolf](https://hacktivis.me/projects/badwolf), [Sphere](https://sphere.tenebris.cc/), [dumb-browser](https://github.com/f32by/dumb-browser), [Breeze](https://github.com/privacyone/breeze-core), [Dot HQ](https://www.dothq.co/) / [Discord](https://invite.gg/dot), [Viper-Browser](https://github.com/LeFroid/Viper-Browser)
+[Hexavalent](https://github.com/Hexavalent-Browser/Hexavalent/releases), [Brave](https://brave.com), [Librewolf](https://gitlab.com/librewolf-community/browser/windows), [Librefox](https://github.com/intika/Librefox/), [Netsurf](https://www.netsurf-browser.org/), [Wexond](https://github.com/wexond/desktop), [Otter](https://otter-browser.org/), [BadWolf](https://hacktivis.me/projects/badwolf), [Sphere](https://sphere.tenebris.cc/), [dumb-browser](https://github.com/f32by/dumb-browser), [Breeze](https://github.com/privacyone/breeze-core), [Dot HQ](https://www.dothq.co/) / [Discord](https://invite.gg/dot), [Viper-Browser](https://github.com/LeFroid/Viper-Browser)
 
 **Android**
 


### PR DESCRIPTION
Removed Ungoogled-Chromium and replaced it with Brave.
Ungoogled chromium has severe security issues that Edge/Brave/Chrome don't have listed below.
https://qua3k.github.io/ungoogled/
Security is necessary for privacy.