### PR TITLE
add google photos takeout helper

### DIFF
--- a/img-tools.md
+++ b/img-tools.md
@@ -337,6 +337,7 @@
 * [Flicker-Download](https://github.com/beaufour/flickr-download) - Flickr Scraper 
 * [iPack Builder](https://www.deviantart.com/mr-blade/art/iPack-Builder-v2-2-Tool-for-icon-customization-473088895), [2](https://mrbladedesigns.com/ipack-builder/) - Create Icon Pack Installers
 * [IndieKids](https://www.indiekids.io/) - Printable Coloring Pages
+* [Google Photos Takeout Helper](https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper) - Cleanup a Google Photos Takeout
 
 ***
 


### PR DESCRIPTION
https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper

"  it organizes and cleans up your Takeout for you
It will take all of your photos from those tiny folders, set their exif and last modified, and other properties correctly, and put it in one big folder (or folders divided by a month) "