### PR TITLE
Add / Remove authenticator apps

### DIFF
--- a/AndroidPiracyGuide.md
+++ b/AndroidPiracyGuide.md
@@ -954,7 +954,7 @@
 
 * [Julioverne](https://julio.hackyouriphone.org/) - Privacy Tools 
 * [iOS-Privacy-Guide](https://github.com/paulaime/iOS-Privacy-Guide) - iOS Privacy Guide
-* [Authy](https://play.google.com/store/apps/details?id=com.authy.authy), [Authenticator](https://mattrubin.me/authenticator), [Obsidian](https://obsidianapp.io/) or [Tofu](https://www.tofuauth.com/) - Two-factor Authentication  
+* [Authy](https://play.google.com/store/apps/details?id=com.authy.authy), [Raivo OTP](https://raivo-otp.com), [OTP Auth](https://apps.apple.com/ca/app/otp-auth/id659877384), [Sentinel](https://getsentinel.io) or [Tofu](https://www.tofuauth.com/) - Two-factor Authentication  
 * [SecretPhotoAlbum++](https://apps.apple.com/us/app/secret-photo-album/id1459036428), [Private Photo Vault](https://apps.apple.com/us/app/private-photo-vault-pic-safe/id417571834) or [No See You](https://noseeyou.com/) - Private Photo Album
 * [Onion Browser](https://onionbrowser.com/) - Onion Browser for iOS 
 * [Firefox Focus](https://apps.apple.com/us/app/firefox-focus-privacy-browser/id1055677337) or [DuckDuckGo Privacy Browser](https://duckduckgo.com/app) - Privacy Based Browser 


### PR DESCRIPTION
Added Raivo OTP (FOSS, simple to use and is recommended by privacytools and privacyguides)
Added OTP Auth (Feature Rich, and also has an Apple Watch App)
Added Sentinel (This used to be obsidian, but they changed names and websites)
Removed Authenticator (Lacks features that the other apps have, and it hasn't been updated in years)