### PR TITLE
single-page: Add SideStore

### DIFF
--- a/single-page
+++ b/single-page
@@ -11089,6 +11089,7 @@ Software
 * [BuildStore](https://builds.io/) - App Store
 * [AppStore](https://t.me/iOSAppsFree) - Tweaked Apps
 * [AltStore](https://altstore.io/) - App Store / [Repo View](https://altsource.by.lao.sb/browse/) / [Alt Daeomon](https://repo.dynastic.co/package/altdaemon) / [Alt Server](https://github.com/NyaMisty/AltServer-Linux)
+* [Sidestore](https://github.com/SideStore/SideStore/) - App Store
 * [ioshaven](https://ioshaven.com/apps) - App Store 
 * [Signulous](https://www.signulous.com/) - App Store / Sideloading
 * [Repo Updates](https://www.ios-repo-updates.com/) - App Repository Updates


### PR DESCRIPTION
Sidestore is a fork of altstore that helps it run without a server.
https://github.com/SideStore/SideStore