### PR TITLE
Update GamingPiracyGuide.md

### DIFF
--- a/GamingPiracyGuide.md
+++ b/GamingPiracyGuide.md
@@ -52,7 +52,6 @@
 * [silentycrying's Game Drive](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/base64#wiki_silentycrying.27s_game_drive) 
 * [DLFox](https://www.dlfox.com/)
 * [Alphagames4u](https://alphagames4u.com/) - [Discord](https://discord.gg/QjrJSs7maj)
-* [DarckRepacks](https://darckrepacks.com/) - [Discord](https://discord.gg/5eRvDvy)
 * [RepackLab](https://repacklab.com/) - [Discord](https://discord.gg/X7sjSxgrfk)
 * [SPiKY Repacks](https://discord.gg/ZHC6pffMz2)
 * [Game Drives](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/base64#wiki_game_drive)


### PR DESCRIPTION
darck repacks is no longer active and their official url also got yeeted. you can check in their discord that they're no longer maintaining the project.