### PR TITLE
Removed onet.pl

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -139,7 +139,6 @@ Simple Allow - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/simple-a
 * https://www.goo.ne.jp/
 * http://www.najdi.si/
 * https://www.naver.com/
-* https://www.onet.pl/
 * https://www.orange.fr/portail
 * http://www.parseek.com/
 * https://www.sapo.pt/


### PR DESCRIPTION
Onet.pl doesn't provide search engine anymore. It uses Google.