### PR TITLE
Update Non-English.md

### DIFF
--- a/Non-English.md
+++ b/Non-English.md
@@ -986,6 +986,7 @@
 * [TelFiles_Bot](https://t.me/TelFiles_Bot) - Persian File to Direct Link Telegram Bot
 * [soft98](https://soft98.ir/) - Software / Courses / eBooks
 * [Persian Telegram Courses](https://rentry.co/sn66v)
+* [Old Persian Games](https://oldpersiangames.org/) - Repository of Iranian Made and Persian Dubbed Games
 * [TeleLeecherbot](https://t.me/TeleLeecherbot) or [kLeechBot](https://t.me/kLeechBot) - Persian Movie Leech Telegram Bots 
 * [FilmgramBot](https://t.me/FilmgramBot) or [FileMovieBot](https://t.me/FileMovieBot) - Persian Movie Search Telegram Bots 
 * [Download.ir](https://download.ir/) - Software / Video / Android / Games / Roms


### PR DESCRIPTION
Old Persian Games is a database for games developed by Iranian developers, many of which are no longer being actively published and need preservation.

It is also a website used to preserve Persian dubs of foreign games released by Iranian publishers (For example [this Persian dub of RE4](https://oldpersiangames.org/games/resident-evil-4-goldensoftware/))