### PR TITLE
Remove AppValley and TutuBox

### DIFF
--- a/AndroidPiracyGuide.md
+++ b/AndroidPiracyGuide.md
@@ -1237,8 +1237,6 @@
 * [App Cake](https://www.iphonecake.com/) - Cracked Apps / [Discord](https://discord.com/invite/TgY2Qmb)
 * [Mobilism iOS Apps](https://forum.mobilism.org/viewforum.php?f=312)
 * [fnd](https://fnd.io/) - App Store Search
-* [AppValley](https://www.appvalley.vip/) - Tweaked App Store
-* [Tutubox](https://tutubox.io/) - Tweaked Apps Store
 * [TweakBox](https://www.tweakboxapp.com/) - App Store
 * [Cydia](https://cydia.saurik.com/) - App Store / [Paid Apps](https://julio.hackyouriphone.org/description.html?id=com.julioverne.cydown) / [Updates](https://t.me/cydiaupdate)
 * [BuildStore](https://builds.io/) - App Store


### PR DESCRIPTION
AppValley and TutuBox are owned by the same person, Colton Adamski. This person has repeatedly been shown to be malicious and send ddos requests to other services such as Scarlet, which is the second biggest sideloading app in the community. He accomplishs this by putting malicious scripts on his websites and using his users internet to constantly request Scarlet's website in a way that will avoid cache in order to run up hundreds in hosting bills and ultimately slow down his site. The fact he weaponizes his users internet is malicious and I don't think these sites should be on this list as it can lead to the user unknowingly being part of a botnet.


Source for the JS: https://web.archive.org/web/20230109093334/http://www.tutubox.io/ (scroll to the bottom)