### PR TITLE
Remove ROMsMania and update CoolROMS

### DIFF
--- a/GamingPiracyGuide.md
+++ b/GamingPiracyGuide.md
@@ -161,7 +161,6 @@
 * [Retrostic](https://www.retrostic.com/) - Emulators / ROMs
 * [Emulanium](https://emulanium.com/) - Emulators / ROMs
 * [ROM Here](https://romhere.com/) - Emulators / ROMs
-* [ROMsMania](https://romsmania.cc/) - Emulators / ROMs
 * [ROMsUniverse](https://www.ROMsuniverse.com/) - Emulators / ROMs
 * [ROMsie](https://ROMsie.com/) - Emulators / ROMs
 * [Romsever](https://romsever.com) - Emulators / ROMs
@@ -184,7 +183,7 @@
 * [HappyROMs](https://happyroms.com/) - Emulators / ROMs
 * [DownloadArea81](https://www.downarea51.com/) - Emulators / ROMs
 * [ROMs Planet](https://romsplanet.com/) - Emulators / ROMs
-* [CoolROMs](https://coolrom.com.au/) - Emulators / ROMs / Use ["Alt DL Link"](https://i.imgur.com/FgHvrPK.png)
+* [CoolROMs](https://coolrom.com.au/) - Emulators / ROMs 
 * [KillerROMs](https://freeromsdownload.com/) -  Emulators / ROMs / Use ["More Options"](https://i.imgur.com/DscRWTR.png)
 * [Nostalgialand](https://nostalgialand.net/) - ROMs
 * [All Xbox Game](https://downloadgamexbox.com/) - ROMs


### PR DESCRIPTION
ROMsMania, owned by down10 (Malicious site: https://www.malwarebytes.com/blog/detections/down10-software) and now goes by retromania after a few name changes. This is in the fmhy unsafe site blocker list, so I feel it's best to remove it from the wiki. Downloading ROMs is strange too, you have to:
- Do the normal "I am not a robot" recaptcha
- Then you have to prove you are not a bot by visiting other sites - Some of which are sites owned by down10 (Appsitory was the first one I got, same loading screen as retromania), sometimes it gives you an "offer", or other times it's just used as ad space

Overall, incredibly sketchy behaviour, should be one to avoid

Coolroms no longer appears to offer their adware downloaders, instead replacing it with a NordVPN ad. Because your ISP is spying on you!!!!!! 

Having uBlock origin enabled while trying to download a ROM doesn't work on this site, it takes you to the completed download page without starting the download. Whether this is something to mention however, I am not sure. It's either on purpose, or the download source is in one of the default filter lists, who knows. 

But what is important is that the Alt Dl link is gone, so best to remove it from the wiki to avoid confusion