### PR TITLE
Remove Anipakku

### DIFF
--- a/single-page
+++ b/single-page
@@ -15378,7 +15378,6 @@ Note - This list only contains sites / tools not found on [PornDude](https://the
 * [Anime Senpai4U](https://www.animesenpai4u.com/) - Sub / Dub
 * [Anime Flix](https://animeflix.org.in/) - Sub / Dub / [Telegram](https://t.me/moviesflixnet)
 * [IndiAnime](https://indianime.com/) - Sub / Dub
-* [Anipakku](https://anipakku.blogspot.com/) - Sub / Dub / [Discord](https://discord.com/invite/ekwtwjwHey)
 * [anime7.download](http://anime7.download/) - Sub
 * [37.187.6.206](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/base64#wiki_37.187.6.206) - Sub
 * [176.36.86.211](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/base64#wiki_176.36.86.211) - Sub / Dub


### PR DESCRIPTION
Removed Anipakku (https://anipakku.blogspot.com/) and moved it to Portuguese anime downloading section since the site is in Portuguese