### PR TITLE
Move Obsidian to "Note Taking Apps" section

### DIFF
--- a/DEVTools.md
+++ b/DEVTools.md
@@ -917,7 +917,6 @@
 * [Markdown To HTML](https://markdowntohtml.com/) - Markdown to HTML Converter
 * [AiToHTML](http://ai2html.org/) - Illustrator to HTML Converter
 * [gd2md-html](https://github.com/evbacher/gd2md-html) - Google Doc to Markdown / HTML Converter
-* [Obsidian](https://obsidian.md/) - Markdown File Organizer / [Resources](https://github.com/kmaasrud/awesome-obsidian) / [Live Sync](https://github.com/vrtmrz/obsidian-livesync) 
 * [MarkdownPastebin](https://markdownpastebin.com/) - Markdown Pastebin
 
 ***

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1717,6 +1717,7 @@ Add the following commands to a search to manually scrape each site.
 #### Note Taking / To Do Apps
 
 * ⭐ **[NoteApps](https://noteapps.info/)** - Note App Index
+* ⭐ **[Obsidian](https://obsidian.md/)** / [Resources](https://github.com/kmaasrud/awesome-obsidian) / [Live Sync](https://github.com/vrtmrz/obsidian-livesync) 
 * ⭐ **[Notion](https://www.notion.so/)**
 * ⭐ **Notion Tools** - [Themes](https://notionthemes.yudax.me/) / [Templates](https://notionpages.com/) / [Resources](https://www.notioneverything.com/notion-world), [2](https://chief-ease-8ab.notion.site/List-of-200-Notion-Resources-e1b46cd365094265bd47b8a2b25bb41e) / [Guide](https://easlo.notion.site/Notion-Beginner-to-Advanced-8a492960b049433289c4a8d362204d20)
 


### PR DESCRIPTION
Obsidian was in [Markup languages](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/dev-tools/#wiki_.25B7_markup_languages) section, however its more appropriate for it to be in [Note taking apps](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage/#wiki_note_taking_.2F_to_do_apps) section