### PR TITLE
Update Non-English.md (elitetorrent domain)

### DIFF
--- a/Non-English.md
+++ b/Non-English.md
@@ -1641,7 +1641,7 @@
 * ⭐ **[DonTorrent](https://dontorrent.care/)**, [2](https://donproxies.com/) - Movies / TV / Documentaries / Games / Castilian / [Telegram](https://t.me/s/dontorrent) / [.onion](https://dontorufwmbqhnoe2wvko5ynis6axf7bqod6wkmdvxmjyek64tantlqd.onion/)
 * ⭐ **[MejorTorrent](https://www1.mejortorrent.rip/)** -  Movies / TV / Documentaries / Castilian / [Telegram](https://t.me/s/MejorTorrentAp)
 * ⭐ **[Grantorrent.wtf](https://grantorrent.wtf/)** - Movies / TV / Documentaries / Castilian / Latino
-* ⭐ **[Elitetorrent](https://www.elitetorrent.com/)**, [2](https://www.elitetorrent.wf/) - Movies / TV / Anime / Castilian / Latino / VOSE
+* ⭐ **[Elitetorrent](https://www.elitetorrent.wf/)** - Movies / TV / Anime / Castilian / Latino / VOSE
 * [Descargas2020](https://descargas2020.net/) - Movies / TV
 * [CalidadTorrent](https://calidadtorrent.com/) - Movies / TV / Documentaries
 * [PediaTorrent](https://pediatorrent.com/) - Movies / TV / Documentaries


### PR DESCRIPTION
the elitetorrent.com domain is different from elitetorrent.wf

.com has shorteners just to get the magnets and .wf doesn't 
So I think its better to just keep .wf

(those shorteners can by bypassed only with my userscript atm: https://greasyfork.org/en/scripts/462510-spanish-torrent-sites-short-link-bypasser but its not even worth it)