### PR TITLE
Update AI.md

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -20,16 +20,16 @@
 
 * ⭐ **[Microsoft Copilot](https://copilot.microsoft.com)** - GPT-4/3.5 Powered Search / [SydneyQT Jailbreak](https://github.com/juzeon/SydneyQt)
 * ⭐ **[wrtn](https://wrtn.ai/)** - GPT-4 Chatbot / [Android](https://play.google.com/store/apps/details?id=com.wrtn.app) / [iOS](https://apps.apple.com/us/app/%EB%A4%BC%ED%8A%BC-%EB%AA%A8%EB%91%90%EB%A5%BC-%EC%9C%84%ED%95%9C-ai-%ED%8F%AC%ED%84%B8/id6448556170) (ask for english)
-* ⭐ **[Gemini](https://gemini.google.com/)** - Google's Chatbot
-* ⭐ **[ChatGPT](https://chat.openai.com/)** - GPT-3.5 Chatbot / [Discord](https://discord.com/invite/openai)
 * ⭐ **[Perplexity](https://www.perplexity.ai/)** - GPT-3.5 Powered Search / [Open Source Models](https://labs.perplexity.ai/)
-* ⭐ **[FlowGPT](https://flowgpt.com/chat)** - Multiple Chatbots / [Discord](https://discord.com/invite/tWZGzcpTkf)
 * ⭐ **[LMSYS Chat](https://chat.lmsys.org/)** - Chat and Compare Multiple Chatbots
+* [ChatGPT](https://chat.openai.com/) - GPT-3.5 Chatbot / [Discord](https://discord.com/invite/openai)
+* [Gemini](https://gemini.google.com/) - Google's Chatbot
+* [groq](https://groq.com/) - LLama and Mixtral Chatbots
+* [HuggingChat](https://huggingface.co/chat/) - Open-Source Chatbots
+* [FlowGPT](https://flowgpt.com/chat) - Multiple Chatbots / [Discord](https://discord.com/invite/tWZGzcpTkf)
 * [Phind](https://www.phind.com/) - GPT-3.5 Powered Search
 * [Ora](https://ora.ai/start) - GPT-3.5 Based Chatbots
-* [HuggingChat](https://huggingface.co/chat/) - Open-Source Chatbots
 * [Pi](https://pi.ai/talk) - Inflection AI's Chatbot
-* [groq](https://groq.com/) - Multiple Chatbots
 * [Poe](https://poe.com/) - Multiple Chatbots / 150 Daily / [Discord](https://discord.com/invite/joinpoe)
 * [Claude](https://claude.ai/) - Anthropic's Chatbot
 * [AI Playground](https://play.vercel.ai/) - Compare Multiple Chatbots


### PR DESCRIPTION
reordered and unstarred some chatbot sites.
mixtral models are better than gpt3.5 plus are uncensored, also gemini free version is not that good, so kept the stars for gpt4 and mixtral models.