### PR TITLE
Update to Image Tools

### DIFF
--- a/docs/img-tools.md
+++ b/docs/img-tools.md
@@ -570,6 +570,7 @@
 * ⭐ **[AntiDupl](https://github.com/ermig1979/AntiDupl)** or [cbird](https://github.com/scrubbbbs/cbird) - Duplicate Image Removers
 * ⭐ **[Muzli](https://search.muz.li/)** - Design Inspiration Search
 * ⭐ **[Slowpoke Pics](https://slow.pics/)**, [ICAT](https://www.nvidia.com/en-us/geforce/technologies/icat/) or [Image Comparison Tool](https://jklgit.github.io/Image-Comparison-in-Browser/index.html) - Image Comparisons
+* ⭐ **[jpeg-quantsmooth](https://github.com/ilyakurdyukov/jpeg-quantsmooth)** or **[jpeg2png Fixed](https://github.com/ThioJoe/jpeg2png)** - Non-AI Based JPEG Smoothers and Artifact Removers
 * [odiff](https://github.com/dmtrKovalenko/odiff) - Image Visual Difference Tool
 * [PhotoFeeler](https://www.photofeeler.com/) - Get Photo Feedback
 * [Picviewer CE+](https://github.com/hoothin/UserScripts/tree/master/Picviewer%20CE+) - Turn Webpages into Image Galleries


### PR DESCRIPTION
Added links for jpeg-quantsmooth and jpeg2png (forked version that fixes a few bugs), which are both tools that reduce compression artifacts in JPEGs (make JPEGs look smoother with fewer artifacts) without the use of AI