### PR TITLE
Added new SlideShare download resource

### DIFF
--- a/docs/edupiracyguide.md
+++ b/docs/edupiracyguide.md
@@ -1355,8 +1355,10 @@
 * [Wordwall](https://wordwall.net/) - Lesson Creator
 * [The Chomsky Index](https://github.com/jasons-gh/the-chomsky-index) - Noam Chomsky Content Index Tool
 * [Internet-In-A-Box](https://internet-in-a-box.org/) - Create Free Offline Learning Hotspots / [GitHub](https://github.com/iiab/iiab)
-* [SlideShareDownloader](https://www.slidesdownloader.com/), [SlidesDownloaders](https://slidesdownloaders.com/) or [SlideShareSaver](https://slidesharesaver.com/) - Download Slideshare Slides
-
+* [SlideShareDownloader](https://www.slidesdownloader.com/),  
+[SlidesDownloaders](https://slidesdownloaders.com/),  
+[SlideShareSaver](https://slidesharesaver.com/),  
+[DownloadSlides](https://downloderslides.com/) - Download SlideShare slides
 ***
 
 ## ▷ Study / Research


### PR DESCRIPTION
Included an additional SlideShare tool [DownloadSlides](https://downloderslides.com/) in the resources list.  
This provides users with another option for downloading presentations in PDF/PPT formats.  
The goal is to give readers more variety and accessibility, similar to the other SlideShare tools already listed.
