### PR TITLE
fix: Change MangaBaka Discord link to canonical official link

### DIFF
--- a/docs/reading.md
+++ b/docs/reading.md
@@ -889,7 +889,7 @@
 * [Oku](https://oku.club/) - Book Tracking Platform
 * [Literal](https://literal.club/) - Social Book Tracking Platform
 * [BookWyrm](https://joinbookwyrm.com/) - Book Tracking Platform / [Official Instance](https://bookwyrm.social/)
-* [MangaBaka](https://mangabaka.dev/) - Multi-Site Manga / Novel Database / [Discord](https://discord.com/invite/XYtPtMkbKs)
+* [MangaBaka](https://mangabaka.dev/) - Multi-Site Manga / Novel Database / [Discord](https://mangabaka.dev/discord)
 * [MangaUpdates](https://www.mangaupdates.com/) - Manga Tracking
 * [Hardcover](https://hardcover.app/) - Tracking / Reviews / Recommendations
 * [LibraryThing](https://www.librarything.com/) - Book Cataloguing Community


### PR DESCRIPTION
👋 Owner of MangaBaka here

We always point to https://mangabaka.dev/discord for Discord, so in case our invite link dies for some reason, we can just update the redirect and not have 1000s of broken links around the internet 

Thank you!

(I'm also Jippi on FMHY Discord in case you need verification)