### PR TITLE
bio.link is no longer free. Removed from internet tools

### DIFF
--- a/docs/internet-tools.md
+++ b/docs/internet-tools.md
@@ -69,7 +69,6 @@
 
 ## ▷ Link in Bio
 
-* ⭐ **[Bio Link](https://bio.link/)** - Unlimited / Custom URLs
 * ⭐ **[Linktree](https://linktr.ee/)** - Unlimited / Custom URLs
 * ⭐ **[Linkstack](https://linkstack.org)** / [GitHub](https://github.com/LinkStackOrg/LinkStack) or **[LittleLink](https://littlelink.io/)** - Unlimited / Custom URLs / Self-Hosted
 * ⭐ **[Carrd](https://carrd.co/)** - Unlimited / Custom URLs / Multiple Designs


### PR DESCRIPTION
bio.link changed to 7 day free trial.