### PR TITLE
Add DAB to audio page

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -350,6 +350,7 @@
 * ⭐ **[lucida](https://lucida.to/)** - Multi-Site / 320kb / MP3 / FLAC / [Telegram](https://t.me/lucidahasmusic) / [Discord](https://discord.gg/5EEexMqVuE)
 * ⭐ **[DoubleDouble](https://doubledouble.top/)** - Multi-Site / 320kb / MP3 / FLAC / [Telegram](https://t.me/lucidahasmusic)
 * ⭐ **[squid.wtf](https://squid.wtf/)** - Khinsider / Tidal / FLAC / [GitHub](https://github.com/QobuzDL/Qobuz-DL)
+* [DAB](https://dab.yeet.su) - Multi-Site / FLAC
 * [YTiz](https://ytiz.xyz/) - YouTube / SoundCloud / Bandcamp / 128kb / AAC / [GitHub](https://github.com/tizerk/ytiz)
 * [AMP3](https://amp3.cc/) - YouTube / 320kb
 * [EzConv](https://ezconv.com/) - YouTube / 320kb


### PR DESCRIPTION
This PR adds **DAB Music Player** to the audio page.

- Great source with:

  - High-quality FLAC tracks
  - Smooth, snappy UI
  - No ads or popups

- The site is temporarily down as of when this PR was made. However:

  - the maintainer seems reasonably active based on the note that's on the page
  - I've been using the site on and off for the last few months and it's always been up throughout that time and working fine 

- Not quite sure what their catalog source is; put `multi site` for now
 