### PR TITLE
Update Freedium link for Medium paywall bypass

### DIFF
--- a/docs/internet-tools.md
+++ b/docs/internet-tools.md
@@ -57,7 +57,7 @@
 
 * ⭐ **[Archive.today](https://archive.is/)** / [.li](https://archive.li/) / [.ph](https://archive.ph/) / [.vn](https://archive.vn/) / [.fo](https://archive.fo/) / [.md](https://archive.md/) - Archived Articles
 * ⭐ **[Bypass Paywalls Clean](https://gitflic.ru/project/magnolia1234/bpc_uploads)** - Browser Extensions / [X](https://x.com/Magnolia1234B)
-* ⭐ **[Freedium](https://freedium.cfd/)**, [ReadMedium](https://readmedium.com/) or [Medium Parser](https://github.com/Xatta-Trone/medium-parser-extension) - Bypass Medium Paywalls
+* ⭐ **[Freedium](https://freedium-mirror.cfd/)**, [ReadMedium](https://readmedium.com/) or [Medium Parser](https://github.com/Xatta-Trone/medium-parser-extension) - Bypass Medium Paywalls
 * ⭐ **[wallabag](https://wallabag.org/)** or [Ladder](https://github.com/everywall/ladder) - Self-Hosted
 * [PaywallBuster](https://paywallbuster.com/) - Paywall Bypass Tools
 * [ByeByePaywall](https://byebyepaywall.com/en/) - Paywall Bypass Tools


### PR DESCRIPTION
I added the working freedium link, got it from the codeberg repository of freedium
https://codeberg.org/Freedium-cfd/web/issues/54

Also, wanted to ask where is the right place to add this app
https://github.com/Sovan22/Medium2Freedium
This is an android app I made to make opening medium links in android a bit easier by just sharing the link to this app and its using freedium to show the article. Just removes the hassle of copying and then opening the link in a seperate browser.

PS : Let me know if it can be added ❤️