### PR TITLE
Amoled toggle fix

### DIFF
--- a/docs/.vitepress/theme/components/ColorPicker.vue
+++ b/docs/.vitepress/theme/components/ColorPicker.vue
@@ -135,7 +135,7 @@ const normalizeColorName = (colorName: string) =>
     <!-- AMOLED toggle -->
     <div class="mt-4 flex items-center gap-2">
       <span class="text-sm text-$vp-c-text-2">AMOLED</span>
-      <Switch @click="isAmoledMode = !isAmoledMode" />
+      <Switch v-model="isAmoledMode" @click="isAmoledMode = !isAmoledMode" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
this makes sure that the toggle doesnt revert back to being off after reloading 

this was an issue that i couldnt test out where the toggle would revert back to the off state while the page remained in the amoled state