### PR TITLE
Add an "Archived" message to Kotatsu. As of today, 11/04/2025 (MM/DD/YYYY), Kotatsu has been discontinued.

### DIFF
--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -783,7 +783,7 @@
 ## ▷ Android Manga
 
 * ⭐ **[Mihon](https://mihon.app/)** - Manga Reader / [Extensions](https://keiyoushi.github.io/extensions/), [2](https://discord.gg/3FbCpdKbdY), [3](https://wotaku.wiki/guides/ext/mihon) / [Endorsed Forks](https://mihon.app/forks/), [2](https://github.com/nekomangaorg/Neko), [3](https://komikku-app.github.io/) / [Discord](https://discord.gg/mihon)
-* ⭐ **[Kotatsu](https://kotatsu.app/)** - Manga Reader / [Nightly](https://github.com/KotatsuApp/Kotatsu-nightly) / [Telegram](https://t.me/kotatsuapp) / [Discord](https://discord.gg/NNJ5RgVBC5)
+* ⭐ **[Kotatsu](https://kotatsu.app/)** - Manga Reader / [Nightly](https://github.com/KotatsuApp/Kotatsu-nightly) / [Telegram](https://t.me/kotatsuapp) / [Discord](https://discord.gg/NNJ5RgVBC5) / ARCHIVED
 * ⭐ **[Dantotsu](https://discord.com/invite/4HPZ5nAWwM)** - Manga Reader / [Extension Guide](https://wotaku.wiki/guides/ext/mihon) / [Source Code](https://git.rebelonion.dev/rebelonion/Dantotsu/) / [Telegram](https://t.me/+gzBCQExtLQo1YTNh)
 * [Mangayomi](https://github.com/kodjodevf/mangayomi) - Manga Reader
 * [LNReader](https://github.com/LNReader/lnreader) - Manga Reader


### PR DESCRIPTION
This pr simply adds "Archived" to Mobile -> Manga Readers -> Kotatsu.

As said in the title, Kotatsu has been archived and will no longer receive official updates from Koitharu (lead developer). The news from their Discord server is that Kakao have struck again, now forcing Kotatsu to shut down. They have also faced challenges with Google's upcoming sideloading policy.

Community mods/forks are still, and will be, fully functional. Talks of a new Kotatsu-based app "Doki" are in the Kotatsu Discord.