### PR TITLE
Add Dizipal and Dizilla to non-English resources

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -1787,6 +1787,8 @@
 * ⭐ **[Yabancıdizi](https://yabancidizi.so/)** - Movies / TV / Sub / Dub / 1080p / [Telegram](https://t.me/s/yabancidizipw)
 * ⭐ **[FullHDFilmizlesene](https://www.fullhdfilmizlesene.de/)**, [2](https://www.fullhdfilmizlesene.com) - Movies / Sub / Dub / 1080p
 * ⭐ **[Dizi Film Botu](https://t.me/Difix9Bot)** - TV / Sub / Dub / Anime / 1080p / 2K / 4K / Movies / TV / Documentaries
+* [Dizipal](https://www.google.com/search?q=dizipal&num=1), [2](https://www.google.com/search?q=dizipalx&num=1) - Movies / TV / Sub / Dub / 1080p
+* [Dizilla](https://dizilla.club) - Movies / TV / Sub / Dub / 1080p
 * [Film Makinesi](https://filmmakinesi.de/) - Movies / TV / Sub / Dub / 1080p
 * [Dizibox](https://www.dizibox.com) - TV / Sub / 1080p
 * [Diziyou](https://www.diziyou.co/) - TV / Sub / Dub / 1080p


### PR DESCRIPTION
The sites remain active. As Dizipal’s URL frequently changes and the number of links continues to grow, access is being redirected via Google.