### PR TITLE
Add Chess Analysis link to gaming documentation

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -557,6 +557,7 @@
 * [Kung Fu Chess](https://www.kfchess.com/) - Real-Time Chess Without Turns
 * [Pokemon Chess](https://pokemonchess.com/) - Pokémon-Style Chess / [Discord](https://discord.gg/fp5bcCqg8q)
 * [ChessBase](https://www.chessbase.in/) / [English](https://en.chessbase.com/) - Indian Chess News
+* [Chess Analysis](https://chess-analysis.org/) - Chess Analysis Online Free
 
 ***
 


### PR DESCRIPTION
Hi,

I have added a link to a free online chess analysis tool.

- **URL:** `https://chess-analysis.org/`
- **Description:** A free online tool for analyzing chess games.
- **Location:** Added to the Gaming section.

Thanks!