### PR TITLE
feat: add Venice.ai and Krea.ai to ai.md

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -338,6 +338,7 @@
 * [Genie](https://lumalabs.ai/genie) / [Discord](https://discord.com/invite/ASbS3EykXm), [Shap-e](https://github.com/openai/shap-e), [Stable Dreamfusion](https://github.com/ashawkey/stable-dreamfusion) or [threestudio](https://github.com/threestudio-project/threestudio) / [Colab](https://colab.research.google.com/github/threestudio-project/threestudio/blob/main/threestudio.ipynb) / [Discord](https://discord.gg/ejer2MAB8N) - 3D Image Generators
 * [Interactive Scenes](https://lumalabs.ai/interactive-scenes) - Generate Interactive Scenes / [Discord](https://discord.com/invite/ASbS3EykXm)
 * [Illusion Diffusion](https://huggingface.co/spaces/AP123/IllusionDiffusion) - Illusion Artwork Generator / [Limits](https://github.com/fmhy/FMHY/wiki/FMHY%E2%80%90Notes.md#hugging-face-warning)
+* [Krea](https://www.krea.ai/) - Real-time Generation / Upscaling / Sign-Up Required / [X](https://x.com/krea_ai) / [Discord](https://discord.gg/krea)
 
 ***
 


### PR DESCRIPTION
### Changes
- Added **Venice.ai** to the "Official Model Sites" section.
- Added **Krea AI** to the "Image Generation" section.

### Context
These are popular AI tools that were missing from the wiki.
- Venice.ai offers private/uncensored AI models.
- Krea AI provides real-time generation and upscaling features.