### PR TITLE
FEAT: Add FocusTube to YouTube Tools

### DIFF
--- a/docs/social-media-tools.md
+++ b/docs/social-media-tools.md
@@ -298,6 +298,7 @@
 # ► YouTube Tools
 
 * ⭐ **[PocketTube](https://pockettube.io/)** or [Kadium](https://kadium.kasper.space/) - Subscription Managers
+* [FocusTube](https://github.com/malekwael229/FocusTube/)
 * [Youtube-shorts block](https://github.com/doma-itachi/Youtube-shorts-block) or [Shorts Deflector](https://evenevan.github.io/shorts-deflector/) / [GitHub](https://github.com/evenevan/shorts-deflector) - Play Shorts In The Normal Desktop Interface
 * [Remove YouTube Shorts](https://addons.mozilla.org/en-US/firefox/addon/remove-youtube-shorts/) or [Hide YT Shorts Filter List](https://github.com/gijsdev/ublock-hide-yt-shorts) - Hide YouTube Shorts
 * [YouTube Wrapped](https://videorecap.viewodyssey.com/) - Personal YouTube Rewind


### PR DESCRIPTION
Hi, I am submitting a new open-source browser extension, FocusTube, for inclusion in the YouTube Tools section.

It's a productivity tool to actively block YouTube Shorts. It uses custom JavaScript logic for Strict Mode (instant redirect) and Soft Mode (full-screen warning overlay), which makes it more active than standard CSS filters.

Status: Code is stable. Live link is pending final approval on the Microsoft Edge Add-ons Store, but the full submission is ready, Also this is just new, I'm planning to update and make it better and better later on.

Thanks for reviewing. ❤️