### PR TITLE
fix: make "Share Feedback" text always white since its background is always black

### DIFF
--- a/docs/.vitepress/theme/components/Feedback.vue
+++ b/docs/.vitepress/theme/components/Feedback.vue
@@ -154,7 +154,7 @@ const toggleCard = () => (isCardShown.value = !isCardShown.value)
               :class="
                 isCardShown === false
                   ? `i-lucide:mail w-6 h-6 text-$vp-c-text-1`
-                  : `i-lucide:mail-x w-6 h-6 text-$vp-c-text-1`
+                  : `i-lucide:mail-x w-6 h-6 text-white`
               "
             />
           </div>
@@ -191,7 +191,7 @@ const toggleCard = () => (isCardShown.value = !isCardShown.value)
             <button
               v-for="item in feedbackOptions"
               :key="item.value"
-                class="bg-[#25262B] border-$vp-c-default-soft hover:border-primary mt-2 select-none rounded border-2 border-solid font-bold transition-all duration-250 rounded-lg text-[14px] font-500 leading-normal m-0 px-3 py-1.5 text-center align-middle whitespace-nowrap"
+                class="bg-[#25262B] border-$vp-c-default-soft hover:border-primary mt-2 select-none rounded border-2 border-solid font-bold transition-all duration-250 rounded-lg text-[14px] text-white font-500 leading-normal m-0 px-3 py-1.5 text-center align-middle whitespace-nowrap"
               @click="handleSubmit(item.value)"
             >
               <span>{{ item.label }}</span>


### PR DESCRIPTION
The Share Feedback button uses a dark background in all theme modes.

This change makes the text color explicitly white, ensuring consistent readability across all three theme modes.

Fixes: #4452 
