### PR TITLE
Replace Polonium with Krohnkite in KDE extensions list

### DIFF
--- a/docs/linux-macos.md
+++ b/docs/linux-macos.md
@@ -500,7 +500,7 @@
 * [Material Shell](https://material-shell.com/) or [Forge](https://github.com/forge-ext/forge) - GNOME Tiling Extension
 * [Pop!_OS Shell](https://github.com/pop-os/shell) - Pop-Shell for GNOME
 * [Guillotine](https://gitlab.com/ente76/guillotine/) - Execute Commands from a Customizable Menu / GNOME Extension
-* [Polonium](https://zeroxoneafour.github.io/polonium/) - KDE6 Tiling Manager Extension
+* [Krohnkite](https://codeberg.org/anametologin/Krohnkite) - KDE6 Dynamic Tiling Extension
 * [Hardcode Tray](https://github.com/bilelmoussaoui/Hardcode-Tray) - Hardcoded Tray Icon Fix
 
 ***


### PR DESCRIPTION
- removed polonium → last update for polonium was last year + repo got archived in Nov
- added krohnkite → highly customizable kwin script via gui for dynamic tiling in KWIN6 (only); currently being maintained