### PR TITLE
fix: preserve TOC visibility and improve toggle consistency

### DIFF
--- a/docs/.vitepress/theme/components/ToggleIndexes.vue
+++ b/docs/.vitepress/theme/components/ToggleIndexes.vue
@@ -61,7 +61,7 @@ const toggleIndexes = (value: boolean) => {
 </template>
 
 <style>
-.indexes-only li:not(.index) {
+.indexes-only .vp-doc li:not(.index) {
   display: none;
 }
 </style>

--- a/docs/.vitepress/theme/components/ToggleStarred.vue
+++ b/docs/.vitepress/theme/components/ToggleStarred.vue
@@ -47,7 +47,7 @@ const toggleStarred = (value: boolean) => {
 </template>
 
 <style>
-.starred-only li:not(.starred) {
+.starred-only .vp-doc li:not(.starred) {
   display: none;
 }
 </style>


### PR DESCRIPTION
This PR addresses a bug where toggling "Starred" or "Indexes" would cause the "On This Page" (Table of Contents) sidebar to become empty or hidden. It also improves the consistency of the toggle components by disabling the toggle starred.

fixes this Issue: #4545 