### PR TITLE
Add RemoteYeah to "Remote Jobs" section

### DIFF
--- a/docs/misc.md
+++ b/docs/misc.md
@@ -830,6 +830,7 @@
 * [DailyRemote](https://dailyremote.com/) - Remote Jobs
 * [HireBasis](https://www.hirebasis.com/) - Remote Jobs
 * [Remotedom](https://remotedom.com/) - Remote Jobs
+* [RemoteYeah](https://remoteyeah.com/) - Remote Engineering Jobs
 
 ***
 


### PR DESCRIPTION
RemoteYeah is a job board featuring remote roles in software engineering, including frontend, backend, full-stack, DevOps, data science, and more.