### PR TITLE
feat: remove Kizzy from mobile list

### DIFF
--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -169,7 +169,6 @@
 * [Mumla](https://gitlab.com/quite/mumla) or [Meshenger](https://github.com/meshenger-app/meshenger-android) - Voice Chat
 * [Aliucord](https://github.com/Aliucord/Manager) - Modded Discord Client / Join [Discord](https://discord.gg/EsNDvBaHVU) for Themes + Plugins
 * [Kettu](https://www.raincord.dev/kettu) - Modded Discord Client / [Discord](https://discord.gg/qkdPGunwjW) / [Codeberg](https://codeberg.org/cocobo1/Kettu) / [GitHub](https://github.com/C0C0B01/Kettu)
-* [Kizzy](https://github.com/dead8309/Kizzy) - Discord Rich Presence
 * [Dumpus](https://github.com/dumpus-app/dumpus-app) - View Discord Data / Self host for Privacy / [Discord](https://androz2091.fr/discord)
 * [DankChat](https://github.com/flex3r/DankChat) - Talk in Multiple Twitch Chats at Once
 * [OldLander](https://github.com/OctoNezd/oldlander) - Improve Old Reddit


### PR DESCRIPTION
Kizzy is a Discord selfbot that does not advertise itself as such, and does not even emulate real client properties (dead8309/Kizzy#56) as is necessary to ensure that Discord accounts are not flagged and banned. The developers have consistently attempted to hide this fact for 4 years by now, and have removed any disclaimers that used to exist about their software being potentially dangerous.