### PR TITLE
Patched up Mod / Data Pack section

### DIFF
--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -701,7 +701,7 @@
 * [No Telemetry](https://modrinth.com/mod/no-telemetry), [2](https://www.curseforge.com/minecraft/mc-mods/no-telemetry) - Disable Telemetry Data / [Github](https://github.com/kb-1000/no-telemetry?tab=readme-ov-file)
 * [SimpleVoicechat](https://modrinth.com/plugin/simple-voice-chat) - Feature-Rich Voice Chat Mod / [Discord](https://discord.gg/4dH2zwTmyX) / [Github](https://github.com/henkelmax/simple-voice-chat)
 * [ReplayMod](https://replaymod.com/) / [Discord](https://discord.com/invite/5GR7RSb) / [Github](https://github.com/ReplayMod/ReplayMod) or [FlashBack](https://modrinth.com/mod/flashback) / [Discord](https://discord.com/invite/mAYDZ9c7rD) / [Github](https://github.com/Moulberry/Flashback?tab=readme-ov-file) - Record Game Sessions
-* [Craftify](https://modrinth.com/mod/craftify) - Display / Control Playing Music Services / [Github](https://github.com/ThatGravyBoat/Craftify)
+* [Craftify](https://modrinth.com/mod/craftify) - Display / Control Playing Music from Streaming Services / [Github](https://github.com/ThatGravyBoat/Craftify)
 * [Vanilla Tweaks](https://www.vanillatweaks.net/) - Semi-custom Resource Packs, Data Packs, and Crafting Tweaks / [X](https://x.com/vanillatweaks) / [Discord](https://discord.com/invite/qG53qwF)
 * [Bedrock Tweaks](https://bedrocktweaks.net/) - Unofficial Vanilla Tweaks Port to Bedrock Edition / [Discord](https://discord.com/invite/xq9JpJ3) / [Github](https://github.com/bedrocktweaks)
 * [Smithed](https://smithed.net/) or [Voodoo Packs](https://mc.voodoobeard.com/) / [Discord](https://discord.gg/SnJQcfq) - Minecraft Data Packs


### PR DESCRIPTION

Added a bunch of links to the sites Github, Discord Reddit etc. Added an extra links to some mods Curseforge with a 2 at the end of the site link.
Reorganized Vanilla Tweaks for Bedrock tweaks to their own line as i thought they didnt fit the description "Minecraft Data Packs" well enough
Changed ViaFabricPlus main link to Modrinth instead of the Github link
Put Mod menu as the first link on the Minecraft Mod Managers line as its the most popular mod manager.
Removed the (fabric) text at the mod menu link as many mods on the list are already fabric only no reason to say it here
Added "from Streaming Services" at the end of Craftify to imply that its coming from streaming services instead of only the vague "Display / Control Playing Music"
<img width="1905" height="1031" alt="image" src="https://github.com/user-attachments/assets/843ebded-5e0d-4120-bfe4-538d2e4e0bdd" />
