### PR TITLE
Add StudyBoost to Specialized Chatbots

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -76,6 +76,7 @@
 * [PrivateGPT](https://privategpt.dev/) - Document Chatbot / Note-Taking / [Discord](https://discord.com/invite/bK6mRVpErU) / [GitHub](https://github.com/zylon-ai/private-gpt)
 * [Onyx](https://www.onyx.app/) - Document Chatbot / Note-Taking / [Discord](https://discord.com/invite/jDnRGhWhg4) / [GitHub](https://github.com/onyx-dot-app/onyx)
 * [DocsGPT](https://www.docsgpt.cloud/) - Document Chatbot / Note-Taking / [Discord](https://discord.com/invite/n5BX8dh8rU) / [GitHub](https://github.com/arc53/DocsGPT)
+* [StudyBoost](https://studyboost.org/) - Document Chatbot / Note-Taking
 * [Hyperspace](https://hyper.space/) - P2P AI Network / [GitHub](https://github.com/hyperspaceai)
 
 ***


### PR DESCRIPTION
## Summary
- Added [StudyBoost](https://studyboost.org/) to the Specialized Chatbots section in `docs/ai.md`
- Categorized as "Document Chatbot / Note-Taking", similar to NotebookLM, PrivateGPT, Onyx, and DocsGPT