### PR TITLE
change amuse to diffuse

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -346,7 +346,7 @@
 * [SD WebUI Forge](https://github.com/lllyasviel/stable-diffusion-webui-forge)
 * [ComfyUI-Zluda](https://github.com/patientx/ComfyUI-Zluda)
 * [⁠Pinokio](https://pinokio.co/) - Plugin-Based / Self-Hosted / NVIDIA Required
-* [⁠Amuse](https://huggingface.co/TensorStack/Amuse) - Stable Diffusion for AMD Systems / [X](https://x.com/Amuse_AI)
+* [⁠Diffuse](https://huggingface.co/TensorStack/Diffuse) - Stable Diffusion for AMD Systems / [Discord](https://discord.gg/ptgMMv36Xu)
 
 ***
 


### PR DESCRIPTION
Tensorstack has archived amuse (https://github.com/TensorStack-AI/AmuseAI)
The successor is diffuse: https://www.reddit.com/r/ROCm/comments/1qsmva8/tensorstack_has_released_diffuse_v_048_its/
This pr replaces amuse with diffuse, and replaces amuse’s x link to diffuses’ discord, as shown on the diffuses’ huggingface profile. 