### PR TITLE
Remove Trackly.cc from torrenting documentation

### DIFF
--- a/docs/torrenting.md
+++ b/docs/torrenting.md
@@ -37,7 +37,6 @@
 * [DaMagNet](https://damag.net/) - DHT-Based
 * [TorrentDownload](https://www.torrentdownload.info/)
 * [TorrentQuest](https://torrentquest.com/)
-* [Trackly.cc](https://trackly.cc/)
 * [Cleanbay](https://cleanbay.netlify.app/)
 * [CloudTorrents](https://cloudtorrents.com/)
 * [Torrents-CSV](https://torrents-csv.com/)


### PR DESCRIPTION
Removed Trackly.cc from the list of torrent sites (Site has been dead for a while, development has stopped).  Side note: development might start again later on, but owner isnt sure.