### PR TITLE
Add Keyboard Tester link to system-tools.md

### DIFF
--- a/docs/system-tools.md
+++ b/docs/system-tools.md
@@ -327,6 +327,7 @@
 * [Cosmos](https://ryanis.cool/cosmos/) - Create Custom Keyboards
 * [Keyboard Simulator](https://keyboardsimulator.xyz/) - Design & Test Virtual Keyboards
 * [Key Test](https://en.key-test.ru/) - Keyboard Tester
+* [Keyboard Tester](https://keyboardtester.pro/) - Free Online Keyboard Testing Tool
 
 ***
 


### PR DESCRIPTION
This pull request adds a link to keyboardtester.pro in system-tools.md.

The tool allows users to quickly test their keyboard online for stuck, ghosting, or non-responsive keys. Including it in the system tools list provides a simple and practical troubleshooting resource for keyboard-related issues.

No other changes were made.