### PR TITLE
Updated french Torrenting websites

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -463,7 +463,11 @@
 
 ## ▷ Torrenting
 
-* [YGGTorrent](https://www.yggtorrent.top/) - Video / Audio / ROMs / Books / Requires Sign-Up
+* [UTOPEER](https://ygg.gratis/) - Video / Audio / ROMs / Books
+* [C411](https://c411.org/) - Video / Audio / ROMs / Books / Requires Sign-Up
+* [Torr9](https://torr9.xyz/) - Video / Audio / ROMs / Books / Requires Sign-Up
+* [G3MINI](https://gemini-tracker.org/) - Video / Audio / ROMs / Books / Requires Sign-Up
+* [La Cale](https://la-cale.space/) - Video / Audio / ROMs / Books / Requires Sign-Up
 * [Torrent9](https://torrent9.to/) - Video / Audio / ROMs / Books
 * [Sharewood](https://www.sharewood.tv/) - Video / Audio / ROMs / Books / Requires Sign-Up
 


### PR DESCRIPTION
YGGTorrent (the biggest french torrenting website) got hacked and closed
Sharewood is about to close in the at the end of month

UTOPEER scraped all YGGTorrent data before the hack and offers all of yggtorrent without sign-up for now. UTOPEER is a federated project of torrenting website, the domain will close at some point and users will have to create nodes to access torrent later on.

C411 was made for replacement of YGGTorrent but does not have as much torrent as YGGTorrent
Others are private torrent website they don't have as big of a database as YGG had