### PR TITLE
Buzzheavier no longer supports torrents

### DIFF
--- a/docs/.vitepress/notes/buzzheavier-warning.md
+++ b/docs/.vitepress/notes/buzzheavier-warning.md
@@ -1,3 +1,3 @@
 #### Buzzheavier Warning
 
-Make sure you have an [adblocker](https://fmhy.net/adblockvpnguide#adblocking) when using Buzzheavier as there are hidden ads on download pages with malicious content. Both the download button and torrent buttons should automatically start a download in your browser, NOT redirect you to another page.
+Make sure you have an [adblocker](https://fmhy.net/adblockvpnguide#adblocking) when using Buzzheavier as there are hidden ads on download pages with malicious content. The download button should automatically start a download in your browser, NOT redirect you to another page.


### PR DESCRIPTION
Clarified the behavior of the download button for Buzzheavier. (Buzz no longer supports torrents)