### PR TITLE
Directory Opus link fix

### DIFF
--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -86,7 +86,7 @@
 
 ## ▷ File Managers
 
-* ⭐ **[Directory Opus](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/download#wiki_.25BA_software_sites)** (search) - Windows File Manager
+* ⭐ **[Directory Opus](https://www.gpsoft.com.au/)** (search) - Windows File Manager
 * [DoubleCMD](https://doublecmd.sourceforge.io/) / [GitHub](https://github.com/doublecmd/doublecmd) or [muCommander](https://www.mucommander.com/) - Cross-Platform File Managers
 * [Sigma](https://sigma-file-manager.vercel.app) - Modern File Manager / [GitHub](https://github.com/aleksey-hoffman/sigma-file-manager)
 * [ChromaFiler](https://chroma.zone/chromafiler/) - Column-Based File Manager


### PR DESCRIPTION
Replaced previous link with the official Directory Opus website.