### PR TITLE
Updated the lists of process managers

### DIFF
--- a/docs/system-tools.md
+++ b/docs/system-tools.md
@@ -23,7 +23,7 @@
 * [PolicyPlus](https://github.com/Fleex255/PolicyPlus) - Local Group Policy Editor
 * [GhostBuster](https://bitbucket.org/wvd-vegt/ghostbuster/src/master/) or [Device Cleanup Tool](https://www.majorgeeks.com/files/details/device_cleanup_tool.html) - Remove Non-Present Devices
 * [Should I Remove It?](https://www.shouldiremoveit.com/) - Program Removal Guide
-* [CoreTemp](https://www.alcpu.com/CoreTemp/) or [System Informer](https://systeminformer.sourceforge.io/) - Process Monitors
+* [CoreTemp](https://www.alcpu.com/CoreTemp/) - Process Monitor
 * [Why Is This Running?](https://github.com/pranshuparmar/witr) - Process Tracing / Debugging
 * [ThrottleStop](https://www.techpowerup.com/download/techpowerup-throttlestop/) - Laptop CPU Monitor / Optimizer
 * [RegExp](https://github.com/zodiacon/TotalRegistry), [RegScanner](https://www.nirsoft.net/utils/regscanner.html), [ripgrep-all](https://github.com/phiresky/ripgrep-all) or [Registry-Finder](https://registry-finder.com/) - Registry Explorers / Scanners
@@ -232,8 +232,7 @@
 * [HWMonitor](https://www.cpuid.com/softwares/hwmonitor.html) - Hardware Monitor
 * [fastfetch](https://github.com/fastfetch-cli/fastfetch) - System Info & Monitoring
 * [⁠btop4win](https://github.com/aristocratos/btop4win) - System Info & Monitoring
-* [⁠NeoHtop](https://abdenasser.github.io/neohtop/) - Task Manager Alt
-* [Task Manager DeLuxe](https://www.mitec.cz/tmx.html) - Task Manager Alt
+* [Task Manager DeLuxe](https://www.mitec.cz/tmx.html), [System Informer](https://systeminformer.sourceforge.io/), [⁠NeoHtop](https://abdenasser.github.io/neohtop/), - Task Manager Alts / [Windows 7 Task Manager](https://win7games.com/#taskmgr7)
 * [Libre Hardware Monitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) - Updated Fork of Open Hardware Monitor
 * [FanControl](https://getfancontrol.com/) / [GitHub](https://github.com/Rem0o/FanControl.Releases) or [FanCtrl](https://github.com/lich426/FanCtrl) - PC Fan Controllers
 * [bottom](https://github.com/ClementTsang/bottom) or [Glances](https://nicolargo.github.io/glances/) / [GitHub](https://github.com/nicolargo/glances) - Terminal Hardware Monitors


### PR DESCRIPTION
I removed System Informer from Process Monitors under System Tools because it really has more inline as a full-fledged Task Manager alternative. It even has a UAC toggle in it to replace the default Task Manager so that seals it. I put it right next to Task Manager DeLuxe under Hardware monitors since that is listed as a Task Manager alt and fit nicely there (No need to create a new entry). I also decided to remove NeoHtop from being its own Task Manager alt entry and merged it with Task Manager DeLuxe and System Informer since I don't think it really needs to be seperate on it's own.

The newest addition made is that I added an entry for a Windows 7 Task Manager that can be used for Windows 10/11. I have tried it and it worked very well in my experience, what-with an option to replace the default Task Manager in Windows 11 and the program being extremely efficent and lightweight since it's literally just the Windows 7 TM (Along with an option to replace the new msconfig.exe with the old one that allows management of startup apps before it got removed). I think some people would enjoy it so I think the addition fits well there. FMHY also lists other old Windows stuff like RetroBar under Customization so it fits with promoting old Windows stuff for new Windows OSs.