### PR TITLE
docs: update Awesome Free Apps repository link

### DIFF
--- a/docs/downloading.md
+++ b/docs/downloading.md
@@ -138,7 +138,7 @@
 
 ## ▷ Freeware Sites
 
-* 🌐 **[Awesome Free Software](https://github.com/johnjago/awesome-free-software)**, [Awesome Free Apps](https://github.com/Axorax/awesome-free-apps), [Windows Ultimate Collection](https://xdaforums.com/t/windows-ultimate-collection-guides.4507867/) or [Free Lunch](https://github.com/auctors/free-lunch) - Freeware Indexes
+* 🌐 **[Awesome Free Software](https://github.com/johnjago/awesome-free-software)**, [Awesome Free Apps](https://github.com/1337Core/awesome-free-apps), [Windows Ultimate Collection](https://xdaforums.com/t/windows-ultimate-collection-guides.4507867/) or [Free Lunch](https://github.com/auctors/free-lunch) - Freeware Indexes
 * 🌐 **[Awesome Python Applications](https://github.com/mahmoud/awesome-python-applications)** - Python App Index
 * ↪️ **[Software Package Managers](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/system-tools#wiki_.25B7_package_managers)**
 * ⭐ **[FluentStore](https://github.com/yoshiask/FluentStore)** - Alt Microsoft Store App / Windows


### PR DESCRIPTION
This pull request updates a link in the freeware sites section of the `docs/downloading.md` documentation. The change replaces the old GitHub repository link that no longer exists with a new maintained repository.

* Updated the "Awesome Free Apps" link in the freeware indexes list to point to `https://github.com/1337Core/awesome-free-apps` instead of the previous repository by Axorax who seems to have disappeared.