### PR TITLE
Fix CreamLinux installer link

### DIFF
--- a/docs/linux-macos.md
+++ b/docs/linux-macos.md
@@ -296,7 +296,7 @@
 * [⁠Faugus Launcher](https://github.com/Faugus/faugus-launcher) - Multi-Game Platform Launcher / Windows Game Launcher
 * [winesapOS](https://github.com/winesapOS/winesapOS) - Play Games on Storage Devices
 * [wine-wayland](https://github.com/varmd/wine-wayland) - Play DX9/DX11 / Vulkan Games
-* [CreamLinux](https://github.com/anticitizn/creamlinux) - Steam DLC Unlocker / [Installer](https://github.com/Novattz/creamlinux-installer)
+* [CreamLinux](https://github.com/anticitizn/creamlinux) - Steam DLC Unlocker / [Installer](https://gitlab.com/tickbaze/creamlinux-installer)
 * [SLSsteam](https://cs.rin.ru/forum/search.php?st=0&sk=t&sd=d&sr=topics&keywords=SLSsteam) - Steamclient Mod w/ DLC Unlocker and Emulated Achievements
 * [⁠SteamTinkerLaunch](https://github.com/sonic2kk/steamtinkerlaunch) - Steam Wrapper w/ Custom Launcher Options
 * [AdwSteamGtk](https://github.com/Foldex/AdwSteamGtk) - Steam Frontend


### PR DESCRIPTION
Updated the link to creamlinux-installer following Novattz's github termination

https://www.reddit.com/r/Creaminstaller/comments/1s81uyd/creamlinuxinstaller_has_been_restricted/

https://cdn.discordapp.com/attachments/1355084977653547040/1488968943128412281/A6AD6DE5-43F5-4D3E-B5E7-FA4C868E12B2.png?ex=69ceb5e3&is=69cd6463&hm=687a761b6594148fb758532da27b8a0861b34c44fdf3d8ff2b1d9ef019f2b098&