### PR TITLE
Removed Magipack from gaming resources 

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -136,7 +136,6 @@
 * [Japanese PC Compendium](https://japanesepccompendium.blogspot.com/) - Retro Japanese PC Games
 * [OldGamesDownload](https://oldgamesdownload.com/) - Abandonware
 * [ClassicPCGames](https://archive.org/details/classicpcgames) - Abandonware
-* [Magipack](https://rentry.co/FMHYB64#magipack) - Abandonware
 * [Old-Games.com](https://www.old-games.com/) - Abandonware / 2 Daily Downloads
 * [Win7Games](https://win7games.com/) - Classic Windows Games
 * [The U-M Software Archives](https://websites.umich.edu/~archive/) - Retro PC / Mac Games


### PR DESCRIPTION
**Removed Magipack link from the abandonware list.** 
Magito stated that his accound got banned and his repacks are forever deleted and he is not either gonna upload them again and asked for his repacks links to be taken down from all sites.
Thank you

<img width="1868" height="565" alt="image" src="https://github.com/user-attachments/assets/fc4783cc-633b-4f35-a7ab-527b8b6e2bf6" />




