### PR TITLE
remove Airsonic from audio.md

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -787,7 +787,7 @@
 ## ▷ Audio Servers
 
 * ⭐ **[Navidrome](https://navidrome.org)**
-* ⭐ **[Airsonic](https://airsonic.github.io/)** or [Airsonic Advanced](https://github.com/airsonic-advanced/airsonic-advanced) / [Web UI](https://github.com/tamland/airsonic-refix)
+* ⭐ **[Airsonic Advanced](https://github.com/airsonic-advanced/airsonic-advanced)** / [Web UI](https://github.com/tamland/airsonic-refix)
 * ⭐ **[koel](https://koel.dev/)**
 * ⭐ **[iBroadcast](https://ibroadcast.com)**
 * ⭐ **[AudioRelay](https://audiorelay.net/)** - Stream Audio Between Devices / [Mobile](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/android#wiki_.25B7_modded_apks) (search)


### PR DESCRIPTION
https://github.com/airsonic/airsonic#airsonic-isnt-maintained-anymore-you-should-migrate-to-airsonic-advanced-instead