### PR TITLE
Add AMWin-RP, Apple Music Rich Presence with Last.fm Scrobbling

### DIFF
--- a/docs/social-media-tools.md
+++ b/docs/social-media-tools.md
@@ -112,6 +112,7 @@
 * [Adobe Discord RPC](https://github.com/teeteeteeteetee/adobe-discord-rpc) - Adobe Rich Presence
 * [PS3 Rich](https://github.com/zorua98741/PS3-Rich-Presence-for-Discord) - PS3 Rich Presence
 * [discord-vscode](https://marketplace.visualstudio.com/items?itemName=icrawl.discord-vscode) - VSCode Rich Presence / [GitHub](https://github.com/iCrawl/discord-vscode)
+* [AMWin-RP](https://github.com/PKBeam/AMWin-RP) - Apple Music Rich Presence w/ Last.fm Scrobbling
 
 ***
 


### PR DESCRIPTION
AMWin-RP is a Windows 11 app that allows for displaying Rich Presence for Apple Music on Discord, with Last.fm scrobbling. Music Presence is currently testing this, but in beta so limited slots. AMWin-RP does this out of the box.