### PR TITLE
Remove UC.Files from filehost section

### DIFF
--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -327,7 +327,6 @@
 * [FileQ](https://fileq.net/) - 50GB / 20GB / 3 Days After Last Download / Has Unlimited Plans / [Discord](https://discord.gg/zc2r9pZzF)
 * [FileMirage](https://filemirage.com/) - 50GB / 30 Days After Last View
 * [Send.now](https://send.now/) - 100GB / 15 Days After Last Download
-* [⁠UC.Files](https://files.union-crax.xyz/) - 25GB / Forever
 * [⁠storage.to](https://storage.to/) - 25GB / 7 Days
 * [Litterbox](https://litterbox.catbox.moe/) - 1GB / 3 Days
 * [Transfer.it](https://transfer.it/) - Unlimited / 90 Days / Owned by MEGA.nz


### PR DESCRIPTION
UC.Files was too good to be true, and will turn invite only. Files can still be downloaded for a few days.