### PR TITLE
feat(video): add FilmU (tv.filmu.in, watch.filmu.in) to Streaming Sites

### DIFF
--- a/docs/video.md
+++ b/docs/video.md
@@ -23,6 +23,7 @@
 * ⭐ **[SpenFlix](https://watch.spencerdevs.xyz/)**, [2](https://spenflix.ru/) - Movies / TV / Anime / Auto-Next / [Discord](https://discord.gg/RF8vMBRtTs)
 * ⭐ **[Cinetaro](https://cinetaro.tv/)** - Movies / TV / Anime / Auto-Next
 * ⭐ **[IceFY](https://icefy.top/)** - Movies / TV / Anime / Auto-Next
+* ⭐ **[FilmU](https://tv.filmu.in/)**, [2](https://watch.filmu.in/) - Movies / TV / Anime / Manga / Radio / IPTV / Live Sports / Auto-Next / Ad-Free Player / 20+ Servers
 * [1Shows](https://www.1shows.nl/), [1Flex](https://www.1flex.nl/) or [RgShows](https://www.rgshows.ru/) - Movies / TV / Anime / [Guide](https://www.rgshows.ru/guide.html) / [Discord](https://discord.gg/the-one) / [Auto Next](https://github.com/fmhy/edit/blob/main/docs/.vitepress/notes/rgshows-autoplay.md)
 * [Cinema.BZ](https://cinema.bz/) - Movies / TV / Anime / Auto-Next / [Telegram](https://t.me/cinemabz)
 * [Movish](https://movish.net/) - Movies / TV / Anime / [Discord](https://discord.gg/FsbU2BQcjQ)


### PR DESCRIPTION
Added tv.filmu.in and watch.filmu.in to the main Streaming Sites section. Features: Movies, TV, Anime, Manga, Radio, IPTV, Live Sports, custom ad-free player, auto-next for anime, and 20+ streaming servers.