### PR TITLE
Add gitty to Git Tools section

### DIFF
--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -166,7 +166,7 @@
 * [git-sim](https://github.com/initialcommit-com/git-sim) - Visually Simulate Git Operations Before Running
 * [GitKraken](https://www.gitkraken.com/) or [Graphite](https://graphite.com/), [Ungit](https://github.com/FredrikNoren/ungit) or [RelaGit](https://rela.dev/) - Git GUIs
 * [lazygit](https://github.com/jesseduffield/lazygit) or [gitui](https://github.com/gitui-org/gitui) - Git TUIs
-* [Gut](https://gut-cli.dev/), [GitHub Cli](https://cli.github.com/) or [gitu](https://github.com/altsem/gitu) - Git CLI / TUI
+* [Gut](https://gut-cli.dev/), [GitHub Cli](https://cli.github.com/), [gitty](https://github.com/Omibranch/gitty) or [gitu](https://github.com/altsem/gitu) - Git CLI / TUI
 * [multi-gitter](https://github.com/lindell/multi-gitter) - Bulk Repository Updater
 * [⁠Difftastic](https://difftastic.wilfred.me.uk/) / [GitHub](https://github.com/Wilfred/difftastic) or [Delta](https://github.com/dandavison/delta) - Syntax Highlighting / Diff Tools
 * [pre-commit](https://pre-commit.com/) - Manage / Maintain Pre-Commit Hooks / [GitHub](https://github.com/pre-commit/)


### PR DESCRIPTION
Adds [gitty](https://github.com/Omibranch/gitty) to the Git CLI line in the Git Tools section.

gitty is a single-binary CLI for Git and GitHub with short, human-readable commands (e.g. \`gitty up\` to stage, commit, and push at once). It's MIT licensed, available via Homebrew (\`brew install gitty\`), winget, and AUR.