### PR TITLE
Add ProxyOrb to proxy services list

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -515,6 +515,7 @@
 * [⁠US5](https://us5.thetravelingtourguide.com/) - Multi-Site + App Proxy / Adblocker / [Discord](https://discord.com/invite/VDA8Ngx38Z)
 * [SSLSecureProxy](https://www.sslsecureproxy.com/), [2](https://www.4everproxy.com/), [3](https://www.hideip.co/)
 * [ProxyOf2](https://proxyof2.com/)
+* [ProxyOrb](https://proxyorb.com/)
 * [Phantom](https://phantom.lol/) / [Discord](https://discord.com/invite/goshadow)
 * [Reflect4](https://reflect4.me/), [CroxyProxy](https://www.croxyproxy.com/) or [Blockaway](https://www.blockaway.net/)
 * [Delusionz](https://delusionz.xyz/) / [Discord](https://discord.com/invite/Dpj8C8SAmH)


### PR DESCRIPTION
Added [ProxyOrb](https://proxyorb.com/) to the list of proxy services.

ProxyOrb is a free web proxy built on Service Worker interception technology so dynamic websites, streaming pages, and modern SPAs keep working.