### PR TITLE
Add Snaplert to Page Change Detection section

### DIFF
--- a/docs/internet-tools.md
+++ b/docs/internet-tools.md
@@ -314,7 +314,7 @@
 * ⭐ **[Flagfox](https://flagfox.wordpress.com/)** - Multi-Tool Firefox Extension for URLs / [Full Tools List](https://files.catbox.moe/s7s4pv.png)
 * ⭐ **[HTTPStatus](https://httpstatus.io/)** - Check URL Status Codes / Redirect Chains
 * ⭐ **[lychee](https://lychee.cli.rs/)** - URL Scanner / [GitHub](https://github.com/lycheeverse/lychee/)
-* [ChangeDetection.io](https://github.com/dgtlmoon/changedetection.io), [urlwatch](https://thp.io/2008/urlwatch/), [Visualping](https://visualping.io/), [Changd](https://github.com/paschmann/changd) or [Follow That Page](https://www.followthatpage.com/) - Page Change Detection / Notification
+* [ChangeDetection.io](https://github.com/dgtlmoon/changedetection.io), [urlwatch](https://thp.io/2008/urlwatch/), [Visualping](https://visualping.io/), [Changd](https://github.com/paschmann/changd), [Follow That Page](https://www.followthatpage.com/) or [Snaplert](https://snaplert.com) - Page Change Detection / Notification
 * [Linkify Plus Plus](https://greasyfork.org/scripts/4255) - Turn Plain Text URLs Into Links
 * [Open Bulk URL](https://openbulkurl.com/), [Multiple Link Opener](https://urltoolshub.com/multiple-link-opener/) or [OpenAllURLs](https://www.openallurls.com/) - Bulk Open URLs
 * [Link Lock](https://rekulous.github.io/link-lock/) - Encrypt & Decrypt Links with Passwords


### PR DESCRIPTION
## What

Adds [Snaplert](https://snaplert.com) to the existing "Page Change Detection / Notification" line in `docs/internet-tools.md`.

## Why Snaplert fits

Snaplert is a hosted website change monitoring tool with features that go beyond the existing entries:
- Visual **pixel-level diffs** with before/after screenshot overlays
- **AI summaries** (Claude) explaining what changed, not just that something changed
- **Element-level zone picker** — monitor specific sections of a page, not the whole page
- 5-minute check intervals
- Email + webhook alerts (Slack, Discord)
- Currently **100% free** during open beta

Useful for tracking price changes, policy updates, job postings, competitor pages, and any content you want to monitor without self-hosting.

The entry fits naturally at the end of the existing comma-separated list, following the established format.