### PR TITLE
Keep the main listing clean by moving extras into one button

### DIFF
--- a/api/routes/service-extras/[page].ts
+++ b/api/routes/service-extras/[page].ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { basename, resolve } from 'pathe'
+import { transform } from '../../../docs/.vitepress/transformer'
+import { attachServiceExtras } from '../../../docs/.vitepress/utils/serviceExtras'
+
+export default defineCachedEventHandler(
+  async (event) => {
+    const page = basename(getRouterParam(event, 'page') || '').replace(/\.md$/i, '')
+
+    if (!page) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Missing page name'
+      })
+    }
+
+    const filePath = resolve(process.cwd(), 'docs', `${page}.md`)
+    if (!existsSync(filePath)) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: 'Page not found'
+      })
+    }
+
+    const raw = readFileSync(filePath, 'utf-8')
+    const { entries } = attachServiceExtras(transform(raw))
+
+    appendResponseHeaders(event, {
+      'cache-control': 'public, max-age=7200',
+      'content-type': 'application/json;charset=utf-8'
+    })
+
+    return {
+      page,
+      entries
+    }
+  },
+  {
+    maxAge: 60 * 60,
+    name: 'service-extras',
+    getKey: (event) => `service-extras:${getRouterParam(event, 'page') || 'unknown'}`
+  }
+)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,7 @@ import { headersPlugin } from './markdown/headers'
 import { toggleStarredPlugin } from './markdown/toggleStarred'
 import { transformsPlugin } from './transformer'
 import { replaceNoteLink } from './utils/markdown'
+import { replaceServiceExtras } from './utils/serviceExtrasMarkdown'
 
 // @unocss-include
 
@@ -225,6 +226,7 @@ export default defineConfig({
       md.use(toggleStarredPlugin)
       meta.build.api && md.use(headersPlugin)
       replaceNoteLink(md)
+      replaceServiceExtras(md)
     }
   },
   themeConfig: {

--- a/docs/.vitepress/theme/components/ServiceExtrasHost.vue
+++ b/docs/.vitepress/theme/components/ServiceExtrasHost.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useMediaQuery } from '@vueuse/core'
+import type { ServiceExtraEntry } from '../../utils/serviceExtras'
+
+const props = defineProps<{ payload: string }>()
+
+const isHoverable = useMediaQuery('(hover: hover)')
+const triggers = computed(() => isHoverable.value ? ['hover'] : ['click'])
+
+const entry = computed(() => {
+  try {
+    return JSON.parse(decodeURIComponent(props.payload)) as ServiceExtraEntry
+  } catch {
+    return null
+  }
+})
+
+const totalItems = computed(() =>
+  entry.value?.groups.reduce((count, group) => count + group.items.length, 0) ?? 0
+)
+</script>
+
+<template>
+  <VDropdown
+    v-if="entry"
+    :triggers="triggers"
+    :popper-triggers="triggers"
+    :delay="{ show: 50, hide: 50 }"
+    :auto-hide="true"
+    :distance="15"
+    placement="auto"
+  >
+    <button
+      type="button"
+      class="service-extras-trigger"
+      :aria-label="`Open extras for ${entry.serviceName}`"
+    >
+      <span class="service-extras-trigger__label">Extras</span>
+      <span v-if="totalItems" class="service-extras-trigger__count">{{ totalItems }}</span>
+    </button>
+
+    <template #popper>
+      <div class="border-$vp-c-divider bg-$vp-c-bg-alt b-rd-4 max-w-md max-h-md border-2 border-solid flex flex-col overflow-hidden">
+        <div class="overflow-y-auto p-4">
+          <h3 class="service-extras-popper__title">{{ entry.serviceName }} extras</h3>
+
+          <div class="service-extras-popper__groups vp-doc">
+            <section
+              v-for="group in entry.groups"
+              :key="group.title"
+              class="service-extras-group"
+            >
+              <p class="service-extras-group__title">{{ group.title }}</p>
+              <div class="service-extras-group__items">
+                <a
+                  v-for="item in group.items"
+                  :key="`${group.title}-${item.label}-${item.href}`"
+                  :href="item.href"
+                  class="service-extras-group__item"
+                >
+                  {{ item.label }}
+                </a>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </template>
+  </VDropdown>
+</template>
+
+<style>
+.service-extras-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-inline-start: 0.45rem;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  font-size: 0.74rem;
+  font-weight: 600;
+  line-height: 1.2;
+  vertical-align: middle;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.service-extras-trigger:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-text-1);
+  background: color-mix(in srgb, var(--vp-c-brand-1) 8%, transparent);
+}
+
+.service-extras-trigger__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1rem;
+  padding: 0 0.28rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--vp-c-brand-1) 16%, transparent);
+  color: var(--vp-c-brand-1);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.service-extras-popper__title {
+  margin: 0 0 0.75rem;
+  color: var(--vp-c-text-1);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.service-extras-popper__groups {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.service-extras-group__title {
+  margin: 0 0 0.4rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.service-extras-group__items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.service-extras-group__item {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.9rem;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  text-decoration: none;
+}
+
+@media (max-width: 640px) {
+  .service-extras-trigger {
+    margin-top: 0.3rem;
+  }
+
+  .service-extras-group__item {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -27,6 +27,7 @@ import Feedback from './components/Feedback.vue'
 import FloatingVue from 'floating-vue'
 import 'floating-vue/dist/style.css'
 import Tooltip from './components/Tooltip.vue'
+import ServiceExtrasHost from './components/ServiceExtrasHost.vue'
 
 export default {
   extends: DefaultTheme,
@@ -37,6 +38,7 @@ export default {
     app.component('Post', Post)
     app.component('Feedback', Feedback)
     app.component('Tooltip', Tooltip)
+    app.component('ServiceExtras', ServiceExtrasHost)
     loadProgress(router)
 
     if (typeof window !== 'undefined') {

--- a/docs/.vitepress/utils/serviceExtras.ts
+++ b/docs/.vitepress/utils/serviceExtras.ts
@@ -1,0 +1,220 @@
+export interface ServiceExtraLink {
+  label: string
+  href: string
+}
+
+export interface ServiceExtraGroup {
+  title: string
+  items: ServiceExtraLink[]
+  contentText: string
+}
+
+export interface ServiceExtraEntry {
+  serviceName: string
+  groups: ServiceExtraGroup[]
+  searchText: string
+}
+
+export interface ServiceExtrasResult {
+  markdown: string
+  entries: ServiceExtraEntry[]
+}
+
+const EXTRA_SUFFIXES = ['tools', 'resources', 'extensions', 'addons', 'add-ons', 'ports']
+const GENERIC_TRAILING_WORDS = ['studio', 'client', 'official']
+const LIST_ITEM_RE = /^[*-] (.+)$/
+const TITLE_BODY_SEPARATOR = ' - '
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '')
+}
+
+export function toPlainText(value: string): string {
+  return value
+    .replace(/\*\*/g, '')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1')
+    .replace(/:[\w-]+:/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function buildTrigger(entry: ServiceExtraEntry): string {
+  const payload = escapeAttribute(encodeServiceExtraEntry(entry))
+  return `<ServiceExtras payload="${payload}" />`
+}
+
+export function parseServiceLine(content: string) {
+  const normalizedContent = content.replace(/^:[\w-]+:\s+/, '').trim()
+  const separatorIndex = normalizedContent.indexOf(TITLE_BODY_SEPARATOR)
+  if (separatorIndex === -1) return
+
+  const titlePart = normalizedContent.slice(0, separatorIndex).trim()
+  const body = normalizedContent.slice(separatorIndex + TITLE_BODY_SEPARATOR.length).trim()
+  const titlePlain = toPlainText(titlePart)
+  const primaryLabel = titlePlain
+    .split(/\s+or\s+|,\s*|\s*\/\s*/i)[0]
+    ?.trim()
+
+  if (!titlePlain || !primaryLabel || !body) return
+
+  return {
+    titlePlain,
+    primaryLabel,
+    body
+  }
+}
+
+function parseListItem(line: string) {
+  const match = line.match(LIST_ITEM_RE)
+  if (!match) return
+
+  const content = match[1]
+  return parseServiceLine(content)
+}
+
+export function createServiceExtraEntry(
+  current: { primaryLabel: string },
+  groups: ServiceExtraGroup[]
+): ServiceExtraEntry {
+  const searchText = groups
+    .map((group) => `${group.title} ${group.contentText}`)
+    .join(' ')
+    .trim()
+
+  return {
+    serviceName: current.primaryLabel,
+    groups,
+    searchText
+  }
+}
+
+export function parseExtraItems(body: string): ServiceExtraLink[] {
+  const items: ServiceExtraLink[] = []
+
+  for (const match of body.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g)) {
+    const suffixMatch = body.slice(match.index! + match[0].length).match(/^\s*(\([^)]*\))/)
+    const suffix = suffixMatch?.[1] ? ` ${suffixMatch[1]}` : ''
+
+    items.push({
+      label: `${match[1]}${suffix}`.trim(),
+      href: match[2]
+    })
+  }
+
+  return items
+}
+
+export function isCompanionTitle(title: string, serviceName: string): boolean {
+  const normalizedTitle = normalize(title)
+  const normalizedService = normalizeAlias(serviceName)
+
+  if (!normalizedTitle || !normalizedService) return false
+  if (normalizedTitle === 'reportissues') return true
+
+  const baseTitle = stripExtraSuffix(title)
+  const normalizedBase = baseTitle ? normalizeAlias(baseTitle) : ''
+  if (!normalizedBase) return false
+
+  return (
+    normalizedBase === normalizedService ||
+    normalizedBase.startsWith(normalizedService) ||
+    normalizedService.startsWith(normalizedBase)
+  )
+}
+
+export function encodeServiceExtraEntry(entry: ServiceExtraEntry): string {
+  return encodeURIComponent(JSON.stringify(entry))
+}
+
+export function attachServiceExtras(text: string): ServiceExtrasResult {
+  const lines = text.split('\n')
+  const output: string[] = []
+  const entries: ServiceExtraEntry[] = []
+
+  for (let index = 0; index < lines.length; index++) {
+    const currentLine = lines[index]
+    const currentItem = parseListItem(currentLine)
+
+    if (!currentItem) {
+      output.push(currentLine)
+      continue
+    }
+
+    const groups: ServiceExtraGroup[] = []
+    let nextIndex = index + 1
+
+    while (nextIndex < lines.length) {
+      const nextItem = parseListItem(lines[nextIndex])
+      if (!nextItem || !isCompanionTitle(nextItem.titlePlain, currentItem.primaryLabel)) {
+        break
+      }
+
+      const items = parseExtraItems(nextItem.body)
+      if (!items.length) {
+        break
+      }
+
+      groups.push({
+        title: nextItem.titlePlain,
+        items,
+        contentText: toPlainText(nextItem.body)
+      })
+      nextIndex++
+    }
+
+    if (!groups.length) {
+      output.push(currentLine)
+      continue
+    }
+
+    const entry = createServiceExtraEntry(currentItem, groups)
+
+    entries.push(entry)
+    output.push(`${currentLine} ${buildTrigger(entry)}`)
+    index = nextIndex - 1
+  }
+
+  return {
+    markdown: output.join('\n'),
+    entries
+  }
+}
+
+function normalizeAlias(value: string): string {
+  let normalizedValue = value.trim()
+
+  for (const word of GENERIC_TRAILING_WORDS) {
+    const suffix = new RegExp(`\\s+${escapeRegExp(word)}$`, 'i')
+    normalizedValue = normalizedValue.replace(suffix, '').trim()
+  }
+
+  return normalize(normalizedValue)
+}
+
+function stripExtraSuffix(title: string): string | null {
+  const trimmedTitle = title.trim()
+
+  for (const suffix of EXTRA_SUFFIXES) {
+    const suffixPattern = new RegExp(`\\s+${escapeRegExp(suffix)}$`, 'i')
+    if (suffixPattern.test(trimmedTitle)) {
+      return trimmedTitle.replace(suffixPattern, '').trim()
+    }
+  }
+
+  return null
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/docs/.vitepress/utils/serviceExtrasMarkdown.ts
+++ b/docs/.vitepress/utils/serviceExtrasMarkdown.ts
@@ -1,0 +1,76 @@
+import type { MarkdownRenderer } from 'vitepress'
+import {
+  buildTrigger,
+  createServiceExtraEntry,
+  isCompanionTitle,
+  parseExtraItems,
+  parseServiceLine,
+  toPlainText
+} from './serviceExtras'
+
+function findListItemClose(tokens: MarkdownRenderer['core']['State']['prototype']['tokens'], start: number) {
+  for (let index = start; index < tokens.length; index++) {
+    if (tokens[index].type === 'list_item_close') return index
+  }
+
+  return -1
+}
+
+export function replaceServiceExtras(md: MarkdownRenderer) {
+  md.core.ruler.after('inline', 'service-extras', (state) => {
+    for (let index = 0; index < state.tokens.length; index++) {
+      if (state.tokens[index].type !== 'list_item_open') continue
+
+      const inlineIndex = index + 2
+      const inlineToken = state.tokens[inlineIndex]
+      if (!inlineToken || inlineToken.type !== 'inline' || !inlineToken.children) continue
+
+      const currentItem = parseServiceLine(inlineToken.content)
+      if (!currentItem) continue
+
+      const groups: Array<{ title: string; items: ReturnType<typeof parseExtraItems>; contentText: string }> = []
+      const removals: Array<{ start: number; end: number }> = []
+      let nextIndex = findListItemClose(state.tokens, index) + 1
+
+      while (nextIndex > 0 && nextIndex < state.tokens.length) {
+        if (state.tokens[nextIndex].type !== 'list_item_open') break
+
+        const nextInlineIndex = nextIndex + 2
+        const nextInlineToken = state.tokens[nextInlineIndex]
+        if (!nextInlineToken || nextInlineToken.type !== 'inline') break
+
+        const nextItem = parseServiceLine(nextInlineToken.content)
+        if (!nextItem || !isCompanionTitle(nextItem.titlePlain, currentItem.primaryLabel)) {
+          break
+        }
+
+        const items = parseExtraItems(nextItem.body)
+        if (!items.length) break
+
+        groups.push({
+          title: nextItem.titlePlain,
+          items,
+          contentText: toPlainText(nextItem.body)
+        })
+
+        const closeIndex = findListItemClose(state.tokens, nextIndex)
+        if (closeIndex === -1) break
+
+        removals.push({ start: nextIndex, end: closeIndex })
+        nextIndex = closeIndex + 1
+      }
+
+      if (!groups.length) continue
+
+      const entry = createServiceExtraEntry(currentItem, groups)
+      const htmlToken = new state.Token('html_inline', '', 0)
+      htmlToken.content = ` ${buildTrigger(entry)}`
+      inlineToken.children.push(htmlToken)
+
+      for (let removalIndex = removals.length - 1; removalIndex >= 0; removalIndex--) {
+        const removal = removals[removalIndex]
+        state.tokens.splice(removal.start, removal.end - removal.start + 1)
+      }
+    }
+  })
+}


### PR DESCRIPTION
Replaces the separate “extras” companion rows with a compact tooltip that matches the existing info modal.
Applies the pattern across docs pages where a service has related tools, resources, or issue links, and keeps the implementation available in both the frontend render path and backend page extras route.