### PR TITLE
Security: Potential rate-limit bypass by trusting unvalidated forwarded IP headers

### DIFF
--- a/api/middleware/ratelimit.ts
+++ b/api/middleware/ratelimit.ts
@@ -17,15 +17,17 @@ export default defineEventHandler(async (event) => {
   const { cloudflare } = event.context
 
   const ipAddress =
-    getHeader(event, 'cf-connecting-ip') ||
-    getHeader(event, 'x-forwarded-for') ||
-    event.node.req.socket.remoteAddress
+    getHeader(event, 'cf-connecting-ip') || event.node.req.socket.remoteAddress
+  const normalizedIpAddress =
+    typeof ipAddress === 'string' && !ipAddress.includes(',')
+      ? ipAddress.trim()
+      : undefined
 
-  if (ipAddress && cloudflare?.env?.RATE_LIMITER) {
+  if (normalizedIpAddress && cloudflare?.env?.RATE_LIMITER) {
     const { success } = await (
       cloudflare.env as unknown as Env
     ).RATE_LIMITER.limit({
-      key: ipAddress
+      key: normalizedIpAddress
     })
 
     if (!success) {


### PR DESCRIPTION
## Problem

Rate-limiting keys use `x-forwarded-for` fallback directly. In deployments where `cf-connecting-ip` is absent or not guaranteed, clients can spoof `x-forwarded-for` to rotate keys and bypass throttling. This impacts both general middleware and feedback submission controls.

**Severity**: `medium`
**File**: `api/middleware/ratelimit.ts`

## Solution

Use only trusted edge-provided client IP headers (e.g., Cloudflare `cf-connecting-ip`) and ignore user-controlled forwarding headers unless sanitized by a trusted proxy chain. Parse and normalize IPs strictly before using as rate-limit keys.

## Changes

- `api/middleware/ratelimit.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
