### PR TITLE
Update audio.md: new link for MusicDL

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -415,6 +415,7 @@
 * [you-get](https://you-get.org/) - SoundCloud / Bilibili / 128kb MP3
 * [BandCamp-DL](https://github.com/iheanyi/bandcamp-dl) - Bandcamp / 128kb MP3 / Free Only / [Discord](https://discord.com/invite/nwdT4MP)
 * [AccurateRip](https://www.accuraterip.com/) - Verify Ripped Tracks are Error-Free
+* [MusicDL](https://github.com/CharlesPikachu/musicdl) - FLAC / Global Multi-platform Aggregation (Spotify, Apple Music, QQ music, etc.) and Download / GUI, CLI, Python
 
 ***
 


### PR DESCRIPTION
first time here, love to hear advice. I am no so sure about the formatting and style.

the proposed new link/tool `Musicdl` is:


A lightweight lossless music downloader that supports dozens of music and audiobook platforms, including major services such as:

Top (most well-known in English-speaking countries):

- Spotify
- Apple Music
- YouTube (YouTube Music)
- SoundCloud

Also supported:

- TIDAL
- Qobuz

(and lots of Asian platforms as well), refer to their repo: https://github.com/CharlesPikachu/musicdl