### PR TITLE
Add ScanRead.ai to Image to Text / OCR

### DIFF
--- a/docs/image-tools.md
+++ b/docs/image-tools.md
@@ -723,6 +723,7 @@
 * [i2ocr](https://www.i2ocr.com/) - Online OCR
 * [GLM-OCR](https://ocr.z.ai/) - Online OCR
 * [OCR.SPACE](https://ocr.space/) - Online OCR
+* [ScanRead.ai](https://scanread.ai/) - Online OCR / 100+ Languages / Handwriting
 * [OCRTool](https://ocrtool.net/) - Online OCR
 * [2OCR](https://2ocr.com/) - Online OCR
 * [OnlineOCR](https://onlineocr.org/) - Online OCR


### PR DESCRIPTION
## What is this?

Adding **ScanRead.ai** to the **Image to Text / OCR** section in `docs/image-tools.md`.

ScanRead.ai is a free online OCR service supporting 100+ languages, with notably strong CJK and handwriting recognition (powered by PP-OCRv5 / PaddleOCR-VL). Generous free tier (20 pages/day, no signup required); exports to `.txt`, `.md`, `.docx`.

**Website:** https://scanread.ai

## Checklist

- [x] Entry inserted in the existing Image to Text / OCR section next to other "Online OCR" entries (after OCR.SPACE)
- [x] Format matches surrounding bullets: `* [Name](url) - Short description`
- [x] No duplicate entry (verified `scanread` not previously present in any FMHY docs)