### PR TITLE
non-english.md: add link to Biblioteca Digital

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -1240,6 +1240,7 @@
 * [RetroArquivo](https://retroarquivo.wordpress.com) - Portuguese Game Magazines
 * [Arquivo.pt](https://arquivo.pt) - History / Sociology / Linguistics Archives
 * [Desciclopédia](https://desciclopedia.org/wiki/P%C3%A1gina_principal) - Wikipedia Parody
+* [Biblioteca Digital](https://bibliotecadigital.aemrt.pt/) - Digital Library
 
 ***
 


### PR DESCRIPTION
Digital Library with Portuguese (PT/PT) eBooks. This digital library features at least 144 different authors and 244 books, most of the content is in the EPUB format and some are in PDF.

see issue: [#5315 ](https://github.com/fmhy/edit/issues/5315)