### PR TITLE
+ TorrentClaw to torrent aggregators

### DIFF
--- a/docs/torrenting.md
+++ b/docs/torrenting.md
@@ -33,6 +33,7 @@
 * ⭐ **[ExT](https://ext.to/)**, [2](https://search.extto.com/) / [Proxy](https://extranet.torrentbay.st/)
 * ⭐ **[BTDigg](https://btdig.com/)** - DHT-Based / [.onion](http://btdigggink2pdqzqrik3blmqemsbntpzwxottujilcdjfz56jumzfsyd.onion/)
 * ⭐ **[Knaben](https://knaben.org/)**
+* **[TorrentClaw](https://torrentclaw.com/)** - File-Verified Aggregator (~10 sources, quality score 0-100, TrueSpec metadata)
 * [TorrentProject](https://torrentproject.cc/), [2](https://torrentproject2.net/) - DHT-Based
 * [DaMagNet](https://damag.net/) - DHT-Based
 * [TorrentDownload](https://www.torrentdownload.info/)


### PR DESCRIPTION
Adds [TorrentClaw](https://torrentclaw.com/) to the Aggregators list in `docs/torrenting.md`.

### Why it fits the list

- **Aggregator**: pulls from ~10 public sources (YTS, EZTV, Knaben, Bitmagnet, Torrentio, Torrents.csv, DonTorrent, Pelispanda, DivxTotal, plus DHT discovery) behind one search.
- **File-verified releases**: TrueSpec scan checks the actual file (codec, audio tracks, subtitle tracks, HDR, real resolution) instead of trusting the filename. Tags `[TrueSpec]` and `[REAL-1080p]` flag the mismatches.
- **Quality score 0-100** appended to each result based on resolution, source, codec, seeders, size, audio, HDR.
- **Public**, no registration to browse. Free API key for the Torznab and JSON endpoints (used by Prowlarr / Sonarr / Radarr / qBittorrent integrations).

### Provided integrations

- Prowlarr / Jackett: Cardigann YAML at https://torrentclaw.com/integrations/prowlarr/torrentclaw.yml — submitted to Prowlarr/Indexers#902 and dreulavelle/Prowlarr-Indexers#108
- qBittorrent: Python plugin at https://torrentclaw.com/integrations/qbittorrent/torrentclaw.py — submitted to LightDestory/qBittorrent-Search-Plugins#36
- Stremio addon, MCP server, CLI client also available

Behind Cloudflare, daily ingestion crons, DMCA process at `/legal/dmca` (~48h response).