### PR TITLE
Add alac_collab_bot to Telegram Bots section

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -423,6 +423,7 @@
 
 * ⭐ **[Music Hunters](https://t.me/MusicsHuntersbot)** - Spotify / Apple / Tidal / Deezer / 320kb MP3
 * [DeezerMusicBot](https://t.me/DeezerMusicBot) - Deezer / Soundcloud / VK / 320kb MP3 / FLAC / [Support](https://t.me/DeezerMusicNews)
+* [alac_collab_bot](https://t.me/alac_collab_bot) / [Channel](https://t.me/apple_music_bot_alac) - Apple Music / ALAC / Atmos / AAC / (Available in IN) / 20 Daily
 * [deezload2bot](https://t.me/deezload2bot) - Deezer / 320kb MP3 / [Updates](https://t.me/DEDSEClulz)
 * [BeatSpotBot](https://t.me/BeatSpotBot) - Spotify / Apple / YouTube / FLAC / 25 Daily
 * [scdlbot](https://t.me/scdlbot) - YouTube / SoundCloud / Bandcamp / Mixcloud / 128kb MP3


### PR DESCRIPTION
Added alac_collab_bot to the Audio Ripping → Telegram Bots section.

Supports Apple Music downloads in:

ALAC
Dolby Atmos
AAC

supports Indian-region Apple Music links with  20 Daily Downloads