### PR TITLE
Add FastScrobbler to last.fm tools

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -730,6 +730,7 @@
 * ⭐ **[Pano Scrobbler](https://github.com/kawaiiDango/pano-scrobbler)** - Multi-Platform Scrobbler
 * ⭐ **[Last.fm Stats](https://lastfmstats.com/)** - In-Depth Last.fm Stats / [GitHub](https://github.com/felhag/lastfm-stats-web)
 * [Web Scrobbler](https://github.com/web-scrobbler/web-scrobbler) - Scrobble Any Site
+* [FastScrobbler](https://github.com/kevinlim512/FastScrobbler) - Lightweight iOS/MacOS scrobbler for Apple Music
 * [Edit Scrobbles](https://greasyfork.org/en/scripts/485278) - Manually Edit Scrobbles
 * [Last.fm Labs](https://www.last.fm/labs) - Last.fm Library Visualizers
 * [Chart My Music](https://www.chartmymusic.com/lastfm/), [TapMusic](https://www.tapmusic.net/), [SonicPrint](https://sonicprint.art/) or [MusicCoruMap](https://musicorumapp.com/generate) - Album Collages


### PR DESCRIPTION
FastScrobbler is an Open Source, lightweight scrobbler for Apple Music on Apple devices that works more consistently than its alternatives. Includes one-time purchasable, non-essential Pro features