### PR TITLE
Add Chesser Resources and Learro

### DIFF
--- a/docs/educational.md
+++ b/docs/educational.md
@@ -115,6 +115,7 @@
 * [ShipSpotting](https://www.shipspotting.com/) - Ship Index / Images
 * [Alchemy Forums](https://alchemyforums.com/index.php) - Alchemy Forum
 * [P2PU](https://www.p2pu.org/) - Join Learning Groups Using Free Courses
+* [Learro](https://learro.com/) - Free Education Resources / Learning
 
 ***
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -30,6 +30,7 @@
 * [NovelsArchive](https://t.me/NovelsArchive) - Books / Telegram
 * [BooksMania](https://t.me/booksmania) - Books / Telegram
 * [FreeBannedBooks](https://freebannedbooks.org/) - US Banned Books
+* [Chesser Resources](https://chesserresources.com.au/) - Free PDF Books / Resources
 * [⁠Inventaire](https://inventaire.io/) - Community Library / Book Lending 
 * [⁠Shelfmark](https://github.com/calibrain/shelfmark) - Ebook Downloader
 * [Calibre](https://calibre-ebook.com/) - Ebook Manager / Downloader / [Libraries / Tools](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/reading#wiki_.25B7_calibre_libraries)


### PR DESCRIPTION
Adds two free, no-paywall educational resources:

- **[Chesser Resources](https://chesserresources.com.au/new/)** — Free document-sharing platform: study notes, exam papers (JEE Mains, CBSE), subject notes (Chemistry, Biology, Physics), books and academic resources. Free signup required to download (anti-bot, not a paywall — no pricing page exists). Added to `reading.md` under Ebooks.
- **[Learro](https://learro.com/)** — Free educational resource for AP exam prep: study guides organized by unit, practice exams, formula sheets, scoring guidelines. Covers AP Calculus AB/BC, Physics, Chemistry, Biology, English, World History, Psychology, Statistics, and more. No signup or paywall. Added to `educational.md` under Learning Sites.

Both are free with no pricing/subscription tiers.