### PR TITLE
Add LegendBar to system tools documentation

### DIFF
--- a/docs/system-tools.md
+++ b/docs/system-tools.md
@@ -439,6 +439,7 @@
 * [Aerial](https://github.com/OrangeJedi/Aerial) - Apple TV Screensaver
 * [ExcelDarkThemeFix](https://github.com/matafokka/ExcelDarkThemeFix) - Fix Excel on Themed Windows
 * [MacType](https://www.mactype.net/) - Use Mac Fonts on Windows / [GitHub](https://github.com/snowie2000/mactype)
+* [LegendBar](https://github.com/Baldev8910/LegendBar) - Menu Bar/Top Bar for Windows 11
 
 ***
 


### PR DESCRIPTION
I would like to bring a menu/top bar for Windows 11, which I'm working on for several months. This menu bar brings a completely new experience to the Windows 11 experience. With features like media player, focus timer (better than native), quick notes, clipboard history, and custom file pins.

It also features 4 materials: Acrylic, Mica, Mica Alt, and Solid Colour. It can be pinned and hidden above as per user preference. The user can toggle widgets as per their liking. And more features are incoming. Check the GitHub page for more information.