### PR TITLE
fix: make navbar dropdowns opaque and fix click-overlap bug

### DIFF
--- a/docs/.vitepress/theme/components/ThemeDropdown.vue
+++ b/docs/.vitepress/theme/components/ThemeDropdown.vue
@@ -182,11 +182,10 @@ onUnmounted(() => {
 
   &:hover {
     color: var(--vp-c-text-1);
-    background: var(--vp-c-bg-elv);
+    background: var(--vp-c-bg);
     transition:
       color 0.25s,
       background 0.25s;
-    backdrop-filter: blur(12px);
   }
 }
 

--- a/docs/.vitepress/theme/components/ThemeDropdown.vue
+++ b/docs/.vitepress/theme/components/ThemeDropdown.vue
@@ -6,6 +6,7 @@ import { useTheme } from '../themes/themeHandler'
 const { mode, amoledEnabled, setAppearance } = useTheme()
 
 const wrapperRef = ref<HTMLElement | null>(null)
+const shown = ref(false)
 
 interface ModeChoice {
   mode: DisplayMode
@@ -79,6 +80,7 @@ const setupParentFlyoutOverride = () => {
   const closeFlyout = (e: MouseEvent) => {
     if (!flyout.contains(e.target as Node)) {
       flyout.classList.remove('open')
+      shown.value = false
     }
   }
 
@@ -105,6 +107,7 @@ onUnmounted(() => {
 <template>
   <div ref="wrapperRef" class="theme-dropdown-wrapper">
     <VDropdown
+      v-model:shown="shown"
       class="theme-dropdown"
       theme="theme-selector"
       :distance="12"

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -431,9 +431,7 @@ body {
 
 /* Global theme styles for the dropdown to ensure correct box appearance */
 .v-popper--theme-theme-selector .v-popper__inner {
-  background: var(--vp-c-bg-elv);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  background: var(--vp-c-bg);
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -460,6 +460,13 @@ body {
   visibility: visible !important;
   transform: translateY(0) !important;
 }
+
+/* Make VPFlyout menu opaque (remove glassmorphism) */
+.VPFlyout .menu {
+  background: var(--vp-c-bg) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
 /* Mobile TOC Active Highlight (Only targets the mobile dropdown) */
 @media (max-width: 1279px) {
   .VPLocalNavOutlineDropdown .outline-link.active {

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -468,6 +468,7 @@ body {
   -webkit-backdrop-filter: none !important;
   border: 1px solid var(--vp-c-divider) !important;
   border-radius: 8px !important;
+  overflow: hidden !important;
 }
 /* Mobile TOC Active Highlight (Only targets the mobile dropdown) */
 @media (max-width: 1279px) {

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -466,6 +466,8 @@ body {
   background: var(--vp-c-bg) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
+  border: 1px solid var(--vp-c-divider) !important;
+  border-radius: 8px !important;
 }
 /* Mobile TOC Active Highlight (Only targets the mobile dropdown) */
 @media (max-width: 1279px) {

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -462,13 +462,12 @@ body {
 }
 
 /* Make VPFlyout menu opaque (remove glassmorphism) */
-.VPFlyout .menu {
+.VPMenu {
   background: var(--vp-c-bg) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   border: 1px solid var(--vp-c-divider) !important;
   border-radius: 8px !important;
-  overflow: hidden !important;
 }
 /* Mobile TOC Active Highlight (Only targets the mobile dropdown) */
 @media (max-width: 1279px) {


### PR DESCRIPTION
## Changes

**Opaque dropdowns:** Removes glassmorphism (backdrop-filter blur + semi-transparent backgrounds) from all navbar dropdown menus.

- ThemeDropdown.vue: removed backdrop-filter blur from toggle hover, switched to solid background
- style.scss: removed backdrop-filter blur from theme-selector popper, switched to solid bg
- style.scss: overrode VPMenu to use solid background with border and border-radius

**Bug fix:** Theme VDropdown no longer stays visible when clicking another nav item (e.g. Ecosystem), preventing overlapping menus.