### PR TITLE
fix: apply grayscale on root .monochrome to cover emoji text too

### DIFF
--- a/docs/.vitepress/theme/components/ThemeDropdown.vue
+++ b/docs/.vitepress/theme/components/ThemeDropdown.vue
@@ -6,6 +6,7 @@ import { useTheme } from '../themes/themeHandler'
 const { mode, amoledEnabled, setAppearance } = useTheme()
 
 const wrapperRef = ref<HTMLElement | null>(null)
+const shown = ref(false)
 
 interface ModeChoice {
   mode: DisplayMode
@@ -79,6 +80,7 @@ const setupParentFlyoutOverride = () => {
   const closeFlyout = (e: MouseEvent) => {
     if (!flyout.contains(e.target as Node)) {
       flyout.classList.remove('open')
+      shown.value = false
     }
   }
 
@@ -105,6 +107,7 @@ onUnmounted(() => {
 <template>
   <div ref="wrapperRef" class="theme-dropdown-wrapper">
     <VDropdown
+      v-model:shown="shown"
       class="theme-dropdown"
       theme="theme-selector"
       :distance="12"

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -89,16 +89,7 @@ body {
 }
 
 .monochrome {
-  [class*='i-'],
-  svg,
-  img:not(.VPImage) {
-    filter: grayscale(100%);
-  }
-
-  .switch,
-  .switch * {
-    filter: none;
-  }
+  filter: grayscale(100%);
 
   .switch {
     background-color: #000;

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -452,14 +452,6 @@ body {
   transform: translateY(0) !important;
 }
 
-/* Make VPFlyout menu opaque (remove glassmorphism) */
-.VPMenu {
-  background: var(--vp-c-bg) !important;
-  backdrop-filter: none !important;
-  -webkit-backdrop-filter: none !important;
-  border: 1px solid var(--vp-c-divider) !important;
-  border-radius: 8px !important;
-}
 /* Mobile TOC Active Highlight (Only targets the mobile dropdown) */
 @media (max-width: 1279px) {
   .VPLocalNavOutlineDropdown .outline-link.active {


### PR DESCRIPTION
Moves `filter: grayscale(100%)` from per-element selectors (`[class*='i-']`, `svg`, `img`) to the root `.monochrome` element so that Unicode emoji text and any other content is also grayscaled in monochrome mode.