### PR TITLE
fix issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/wiki.yml
+++ b/.github/ISSUE_TEMPLATE/wiki.yml
@@ -10,8 +10,8 @@ body:
     attributes:
       value: |
         ### Things to note
-        * Anyone can suggest [changes or corrections](https://rentry.org/fmhyedit) to the wiki. Please read our [Contribution Guide](https://rentry.co/Contrib-Guide) before trying to add or remove anything.
-        * If you're adding a new site, please [search](https://raw.githubusercontent.com/fmhy/edit/main/single-page) (control + f) first to make sure we don't already have it.
+        * Anyone can suggest [changes or corrections](https://fmhy.net/other/contributing) to the wiki. Please read our [Contribution Guide](https://fmhy.net/other/contributing) before trying to add or remove anything.
+        * If you're adding a new site, please [search](https://api.fmhy.net/single-page) (control + f) first to make sure we don't already have it.
         * Approved changes will be applied to the [site](https://fmhy.net) and all [🔒 backups](https://github.com/fmhy/FMHY/wiki/Backups).
         * You can send us stuff directly via [💬 Discord](https://github.com/fmhy/FMHY/wiki/FMHY-Discord).
         * You can also check out our [website](https://fmhy.net) and the [posts](https://fmhy.net/posts) section to know about any major updates to the wiki.


### PR DESCRIPTION
updates a couple links in the issue template:

- single-page search now points to the working api.fmhy.net page
- contribution guide now points to the current fmhy contributing page

checked that the old single-page raw github link 404s and the new links load.