### PR TITLE
Added Kelutral as a place to learn Na'vi language

### DIFF
--- a/docs/educational.md
+++ b/docs/educational.md
@@ -1214,6 +1214,7 @@
 * [Eberban](https://eberban.github.io/eberban/) / [Discord](https://discord.gg/FChFEHEet8) or [Learn Eberban](https://learn-eberban.github.io/) - Eberban Language Learning / Focused on Simplicity, Expressivness & Regularity
 * [Xextan](https://xextan.github.io/) - Xextan Language Learning / Focused on Simplicity + Ease of Learning / [Wiki](https://xextan.miraheze.org/wiki/Main_Page) / [Discord](https://discord.gg/4Wz7EeQJ2g)
 * [Learn Na'vi](https://learnnavi.org/) - Na’vi (Avatar) Language Learning / Community / [Forum](https://forum.learnnavi.org/) / [Discord](https://discord.gg/LearnNavi)
+* [Kelutral](https://kelutral.org/) - Na’vi (Avatar) Language Learning / Community / [Discord](https://discord.gg/9jTKppA3sE)
 
 ***
 


### PR DESCRIPTION
There are three main communities for learning Na'vi language:
- Learn Na'vi (already listed)
- Kelutral (has nearly as many Discord members as Learn Na'vi as well as more Discord channels)
- Deutsche Na'vi Lerngruppe (a smaller community where German speakers learn Na'vi language.  Not added because of the rules about non-English software)

Oh, at the end of a bonus feature for *Avatar: Fire and Ash*, there are three links: https://learnnavi.org/, https://kelutral.org/ and https://naviteri.org/.  The last one is the blog of Paul Frommer, the guy who made and maintains the Na'vi language