### PR TITLE
audio: add AWE Radio to User-Stations

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -245,6 +245,7 @@
 * [ShoutCast](https://directory.shoutcast.com/) - User-Stations
 * [Zeno.fm](https://zeno.fm/) - User-Stations
 * [Live365](https://live365.com/) - User-Stations
+* [AWE Radio](https://aweradio.app/) - User-Stations / iOS + CarPlay
 * [Internet-Radio](https://internet-radio.com/) - Station-Directory
 * [⁠WFMU](https://wfmu.org/) - Independent Internet Radio
 * [deepcut.fm](https://deepcut.live/) - Deep-Cuts


### PR DESCRIPTION
Adds AWE Radio to the User-Stations cluster in Internet Radio.

**About:** Free web-based platform where anyone can run their own 24/7 internet radio station. No listener account required to tune in. Same shape as ShoutCast / Zeno.fm / Live365.

**Why this entry / placement:**
- Cluster: matches the existing User-Stations lineup
- Position: end of cluster (newest, not claiming a top spot)
- Description: `iOS + CarPlay` is the genuine differentiator vs the neighbours — none of them ship a native CarPlay app

**Already checked:** confirmed not present in the wiki.

Single-line addition to `docs/audio.md`. Happy to adjust placement or wording.