### PR TITLE
Add Streamzy to streaming services list

### DIFF
--- a/docs/video.md
+++ b/docs/video.md
@@ -538,6 +538,7 @@
 * [Strumyk](https://strumyk.net/), [2](https://strims24.pl/)
 * [StreamCorner](https://streamcorner.fyi/), [2](https://streamcorner.io/), [3](https://streamcorner.site/) or [StreamNinja](https://streamninja.xyz/), [2](https://streamninja.online/) / [Status](https://beacons.ai/streamcorner) / [Discord](http://discord.gg/vV6rRFtWhW)
 * [⁠Streami](https://streami.click/)
+* [Streamzy](https://streamzy.pages.dev) - Streamed Mirror
 * [xyzstreams](https://xyzstreams.shop/)
 * [TVPass](https://the-tv.app/) - US Only / [Discord](https://discord.gg/4qMfKq6NMH)
 * [CricHD](https://crichd.at/), [2](https://crichd.com.co/)


### PR DESCRIPTION
This pull request makes a small documentation update by adding a new streaming mirror site to the list in `docs/video.md`. The change is straightforward and adds visibility to an additional resource for users. 

* Added `Streamzy` (https://streamzy.pages.dev) as a new streamed mirror in the list of streaming sites in `docs/video.md`.