### PR TITLE
Added Mercado Play

### DIFF
--- a/docs/video.md
+++ b/docs/video.md
@@ -211,6 +211,7 @@
 * [ARTE](https://www.arte.tv/en) - Movies / TV / Auto-Next
 * [BBC iPlayer](https://www.bbc.co.uk/iplayer) - Movies / TV / Requires UK VPN (windscribe) / [Downloader](https://github.com/get-iplayer/get_iplayer)
 * [FlixHouse](https://flixhouse.com/) - Indie Movies
+* [Mercado Play (by Mercado Libre)](https://play.mercadolibre.com) - Movies / Latin America Only / Requires Sign-Up
 
 ***
 


### PR DESCRIPTION
Mercado Play is a free w/ ads streaming platform built by the biggest company in Latin America, Mercado Libre. This makes it very reliable, secure and well-known.