### PR TITLE
Add Moovie as a streaming option

### DIFF
--- a/docs/video.md
+++ b/docs/video.md
@@ -52,6 +52,7 @@
 * [Nxsha](https://web.nxsha.app/) - Movies / TV / Anime / [Telegram](https://telegram.me/+8_u943HkSAY5ODA1)
 * [PlayTorrio](https://playtorrio.xyz/) - Streaming Desktop App / Use Streaming Mode / [Subreddit](https://www.reddit.com/r/PlayTorrio/) / [Discord](https://discord.gg/bbkVHRHnRk) / [GitHub](https://github.com/ayman708-UX/PlayTorrioV2)
 * [mov-cli](https://mov-cli.github.io/) - Streaming CLI / [Plugins](https://github.com/topics/mov-cli-plugin) / [Discord](https://discord.gg/BMzC7ePsBV) / [GitHub](https://github.com/mov-cli/mov-cli)
+* [Moovie](https://moovie.fun/) - Movies / TV / Anime / Watchtogether
 
 ***
 


### PR DESCRIPTION
I have made the site more stable since last rejection.

Removed non-functional video servers for users ease to access

Added a region feature too, if user is from X region, they can switch to X region and watch regional content.

The site loads faster than before.

Kindly recheck the website, thanks.