### PR TITLE
Add SongFromLink to Song Identification

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -846,6 +846,7 @@
 * [FlairMax](https://apps.microsoft.com/detail/9pdzvj34ztxg) / Windows
 * [AudioTag](https://audiotag.info/) / Web
 * [⁠SongFinder](https://songfinder.gg/) / Web
+* * [SongFromLink](https://songfromlink.com/) - Find the Song from a TikTok / Reels / Shorts Link / Web
 * [SoundHound](https://www.soundhound.com/soundhound) / Android, iOS
 * [Audile](https://github.com/aleksey-saenko/MusicRecognizer) / Android
 * [Audire](https://github.com/alexmercerind/audire) / Android


### PR DESCRIPTION
Adds SongFromLink to the Song Identification list.

It's a free web tool: paste a TikTok / YouTube Shorts / Instagram or Facebook Reels link and it identifies the background song. No extension or signup. Complements the existing link/web identifiers (SongFinder, AHA Music) by focusing on social-video links.