### PR TITLE
Update privacy.md

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -444,8 +444,8 @@
 
 # ► Proxy
 
+* ⭐ **[Lantern](https://lantern.io/)** - Proxy App / VPN / [GitHub](https://github.com/getlantern/lantern)
 * [Psiphon](https://psiphon.ca/) - Hybrid Proxy VPN App
-* [Lantern](https://lantern.io/) - Proxy App / Slowed Past 250MB / [GitHub](https://github.com/getlantern/lantern)
 * [FreeSocks](https://freesocks.org/) - Shadowsocks App / [GitHub](https://github.com/unredacted/freesocks-control-plane)
 * [Snowflake](https://snowflake.torproject.org/) - Tor Proxy Browser Extension
 * [Censor Tracker](https://censortracker.org/) / [Telegram](https://t.me/CensorTracker_feedback) / [GitHub](https://github.com/censortracker/censortracker), [SmartProxy](https://github.com/salarcode/SmartProxy), [FoxyProxy](https://getfoxyproxy.org/) or [ZeroOmega](https://github.com/zero-peak/ZeroOmega) - Proxy Extensions


### PR DESCRIPTION
Starred Lantern VPN under Proxy. 
The speed limit after 250 mb has been removed and the vpn is much faster than before. It has also gotten a major UI/UX update. 

Additionally, this VPN works on networks that block all other VPNs.