### PR TITLE
Revise June 2026 updates with new content and features

### DIFF
--- a/docs/posts/june-2026.md
+++ b/docs/posts/june-2026.md
@@ -70,7 +70,9 @@ in seeing all minor changes you can follow our
 
 - Starred ⁠[SteaMidra](https://fmhy.net/gaming-tools#steam-epic) in Steam Tools, multi-tool that includes DLC unlockers, multiplayer fixes, and a manifest tool.
 
+
 - Starred [ReadYou](https://fmhy.net/mobile#android-rss-readers) in Android RSS Readers, clean design, offline support, Google Reader + Fever API sync
+-  Starred ⁠[SteaMidra]() in Steam Tools, multi-tool that includes DLC unlockers, multiplayer fixes, and a manifest tool.
 
 - Starred [Gadgetbridge](https://fmhy.net/mobile#android-utilities) in Android Utilities, open-source gadget manager w/ support for 300+ devices and no account required.
 


### PR DESCRIPTION
Updated the June 2026 monthly updates with new features, removals, and starred items. Added sections for various topics and improved search functionality.