### PR TITLE
adding my list page

### DIFF
--- a/docs/.vitepress/shared.ts
+++ b/docs/.vitepress/shared.ts
@@ -36,7 +36,8 @@ export const excluded = [
   'feedback.md',
   'index.md',
   'sandbox.md',
-  'startpage.md'
+  'startpage.md',
+  'my-list.md'
 ]
 
 const safeEnv = (key: string) =>
@@ -112,6 +113,10 @@ export const nav: DefaultTheme.NavItem[] = [
 ]
 
 export const sidebar: DefaultTheme.Sidebar | DefaultTheme.NavItemWithLink[] = [
+  {
+    text: '<span class="i-twemoji:bookmark"></span> My List',
+    link: '/my-list'
+  },
   {
     text: '<span class="i-twemoji:books"></span> Beginners Guide',
     link: '/beginners-guide'

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -4,6 +4,7 @@ import DefaultTheme from 'vitepress/theme'
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 import Announcement from './components/Announcement.vue'
 import Base64Dialog from './components/Base64Dialog.vue'
+import DocLinkBookmarks from './components/DocLinkBookmarks.vue'
 import Sidebar from './components/SidebarCard.vue'
 
 const { Layout } = DefaultTheme
@@ -127,6 +128,7 @@ onUnmounted(() => {
     :url="formattedUrl"
     @close="showBase64Dialog = false"
   />
+  <DocLinkBookmarks />
 </template>
 
 <style>

--- a/docs/.vitepress/theme/components/DocLinkBookmarks.vue
+++ b/docs/.vitepress/theme/components/DocLinkBookmarks.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { useData, useRoute } from 'vitepress'
+import { nextTick, onBeforeUnmount, onMounted, watch } from 'vue'
+import { useLinkBookmarks } from '../composables/linkBookmarks'
+import {
+  extractRowFromLi,
+  getMainLink,
+  normalizeBookmarkUrl,
+  normalizePagePath,
+  resolveLinkHref
+} from '../composables/savedRowUtils'
+import { rememberPageRow } from '../composables/useSavedRowResolver'
+
+const route = useRoute()
+const { site } = useData()
+const { bookmarks, isBookmarked, toggle, updateSnapshot } = useLinkBookmarks()
+
+const MY_LIST_PATH = '/my-list'
+
+let enhanceFrame = 0
+
+function syncButtonState(button: HTMLButtonElement, url: string) {
+  const saved = isBookmarked(url)
+  button.classList.toggle('is-saved', saved)
+  button.setAttribute('aria-pressed', saved ? 'true' : 'false')
+  button.setAttribute(
+    'aria-label',
+    saved ? 'Remove bookmark' : 'Bookmark this link'
+  )
+
+  const label = button.querySelector('.link-bookmark-label')
+  if (label) label.textContent = saved ? 'Bookmarked' : 'Bookmark'
+}
+
+function syncAllButtons() {
+  document
+    .querySelectorAll<HTMLButtonElement>('.link-bookmark-btn')
+    .forEach((button) => {
+      const url = button.dataset.url
+      if (url) syncButtonState(button, url)
+    })
+}
+
+function createTooltip(
+  link: HTMLAnchorElement,
+  li: HTMLLIElement,
+  href: string
+) {
+  const tooltip = document.createElement('span')
+  tooltip.className = 'fmhy-bookmark-tooltip'
+  tooltip.setAttribute('role', 'tooltip')
+
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = 'link-bookmark-btn'
+  button.dataset.url = href
+  button.innerHTML =
+    '<span class="link-bookmark-icon i-lucide:bookmark shrink-0 w-3.5 h-3.5" aria-hidden="true"></span><span class="link-bookmark-label">Bookmark</span>'
+
+  button.addEventListener('click', (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const url = normalizeBookmarkUrl(resolveLinkHref(link))
+    const page = normalizePagePath(route.path, site.value.base)
+    const row = extractRowFromLi(li)
+    const saved = toggle({
+      url,
+      page,
+      html: row.html,
+      classes: row.classes
+    })
+
+    if (saved) rememberPageRow(page, site.value.base, url, row)
+    syncButtonState(button, url)
+  })
+
+  tooltip.appendChild(button)
+  syncButtonState(button, href)
+  return tooltip
+}
+
+function unwrapEnhancedLinks(root: ParentNode) {
+  root.querySelectorAll('.fmhy-link-wrap').forEach((wrap) => {
+    const parent = wrap.parentNode
+    if (!parent) return
+
+    while (wrap.firstChild) {
+      parent.insertBefore(wrap.firstChild, wrap)
+    }
+    parent.removeChild(wrap)
+  })
+}
+
+function enhanceLink(link: HTMLAnchorElement, li: HTMLLIElement) {
+  const href = link.href
+  if (!href) return
+
+  const wrap = document.createElement('span')
+  wrap.className = 'fmhy-link-wrap'
+
+  link.parentNode?.insertBefore(wrap, link)
+  wrap.appendChild(link)
+  wrap.appendChild(createTooltip(link, li, href))
+}
+
+function enhanceLinks() {
+  if (normalizePagePath(route.path, site.value.base) === MY_LIST_PATH) return
+
+  const doc = document.querySelector('.VPDoc .content-container .vp-doc')
+  if (!doc) return
+
+  unwrapEnhancedLinks(doc)
+
+  doc.querySelectorAll<HTMLLIElement>('li').forEach((li) => {
+    const link = getMainLink(li)
+    if (!link) return
+
+    const url = normalizeBookmarkUrl(resolveLinkHref(link))
+    if (isBookmarked(url)) {
+      const row = extractRowFromLi(li)
+      updateSnapshot(url, row)
+      rememberPageRow(
+        normalizePagePath(route.path, site.value.base),
+        site.value.base,
+        url,
+        row
+      )
+    }
+
+    enhanceLink(link, li)
+  })
+}
+
+function scheduleEnhance() {
+  cancelAnimationFrame(enhanceFrame)
+  enhanceFrame = requestAnimationFrame(() => {
+    nextTick(() => enhanceLinks())
+  })
+}
+
+function onStorage(event: StorageEvent) {
+  if (event.key === 'fmhy-saved-links') syncAllButtons()
+}
+
+onMounted(() => {
+  scheduleEnhance()
+  window.addEventListener('storage', onStorage)
+})
+
+onBeforeUnmount(() => {
+  cancelAnimationFrame(enhanceFrame)
+  window.removeEventListener('storage', onStorage)
+})
+
+watch(
+  () => route.path,
+  () => scheduleEnhance()
+)
+
+watch(bookmarks, () => syncAllButtons(), { deep: true })
+</script>
+
+<template>
+  <span hidden aria-hidden="true" />
+</template>

--- a/docs/.vitepress/theme/components/DocLinkBookmarks.vue
+++ b/docs/.vitepress/theme/components/DocLinkBookmarks.vue
@@ -41,6 +41,50 @@ function syncAllButtons() {
     })
 }
 
+function bookmarkFromLi(link: HTMLAnchorElement, li: HTMLLIElement) {
+  const url = normalizeBookmarkUrl(resolveLinkHref(link))
+  const page = normalizePagePath(route.path, site.value.base)
+  const row = extractRowFromLi(li)
+  const saved = toggle({
+    url,
+    page,
+    html: row.html,
+    classes: row.classes
+  })
+
+  if (saved) rememberPageRow(page, site.value.base, url, row)
+
+  li.querySelectorAll<HTMLButtonElement>('.link-bookmark-btn').forEach(
+    (button) => syncButtonState(button, url)
+  )
+}
+
+function createBookmarkButton(
+  link: HTMLAnchorElement,
+  li: HTMLLIElement,
+  href: string,
+  inline = false
+) {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = inline
+    ? 'link-bookmark-btn link-bookmark-btn--inline'
+    : 'link-bookmark-btn'
+  button.dataset.url = href
+  button.innerHTML = inline
+    ? '<span class="link-bookmark-icon" aria-hidden="true"></span>'
+    : '<span class="link-bookmark-icon" aria-hidden="true"></span><span class="link-bookmark-label">Bookmark</span>'
+
+  button.addEventListener('click', (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    bookmarkFromLi(link, li)
+  })
+
+  syncButtonState(button, href)
+  return button
+}
+
 function createTooltip(
   link: HTMLAnchorElement,
   li: HTMLLIElement,
@@ -49,38 +93,24 @@ function createTooltip(
   const tooltip = document.createElement('span')
   tooltip.className = 'fmhy-bookmark-tooltip'
   tooltip.setAttribute('role', 'tooltip')
-
-  const button = document.createElement('button')
-  button.type = 'button'
-  button.className = 'link-bookmark-btn'
-  button.dataset.url = href
-  button.innerHTML =
-    '<span class="link-bookmark-icon i-lucide:bookmark shrink-0 w-3.5 h-3.5" aria-hidden="true"></span><span class="link-bookmark-label">Bookmark</span>'
-
-  button.addEventListener('click', (event) => {
-    event.preventDefault()
-    event.stopPropagation()
-
-    const url = normalizeBookmarkUrl(resolveLinkHref(link))
-    const page = normalizePagePath(route.path, site.value.base)
-    const row = extractRowFromLi(li)
-    const saved = toggle({
-      url,
-      page,
-      html: row.html,
-      classes: row.classes
-    })
-
-    if (saved) rememberPageRow(page, site.value.base, url, row)
-    syncButtonState(button, url)
-  })
-
-  tooltip.appendChild(button)
-  syncButtonState(button, href)
+  tooltip.appendChild(createBookmarkButton(link, li, href))
   return tooltip
 }
 
+function createInlineBookmark(
+  link: HTMLAnchorElement,
+  li: HTMLLIElement,
+  href: string
+) {
+  const wrap = document.createElement('span')
+  wrap.className = 'fmhy-bookmark-inline'
+  wrap.append(' / ')
+  wrap.appendChild(createBookmarkButton(link, li, href, true))
+  return wrap
+}
+
 function unwrapEnhancedLinks(root: ParentNode) {
+  root.querySelectorAll('.fmhy-bookmark-inline').forEach((el) => el.remove())
   root.querySelectorAll('.fmhy-link-wrap').forEach((wrap) => {
     const parent = wrap.parentNode
     if (!parent) return
@@ -93,15 +123,21 @@ function unwrapEnhancedLinks(root: ParentNode) {
 }
 
 function enhanceLink(link: HTMLAnchorElement, li: HTMLLIElement) {
-  const href = link.href
+  const href = normalizeBookmarkUrl(resolveLinkHref(link))
   if (!href) return
 
-  const wrap = document.createElement('span')
-  wrap.className = 'fmhy-link-wrap'
+  if (!link.closest('.fmhy-link-wrap')) {
+    const wrap = document.createElement('span')
+    wrap.className = 'fmhy-link-wrap'
 
-  link.parentNode?.insertBefore(wrap, link)
-  wrap.appendChild(link)
-  wrap.appendChild(createTooltip(link, li, href))
+    link.parentNode?.insertBefore(wrap, link)
+    wrap.appendChild(link)
+    wrap.appendChild(createTooltip(link, li, href))
+  }
+
+  if (!li.querySelector('.fmhy-bookmark-inline')) {
+    li.appendChild(createInlineBookmark(link, li, href))
+  }
 }
 
 function enhanceLinks() {

--- a/docs/.vitepress/theme/components/MyList.vue
+++ b/docs/.vitepress/theme/components/MyList.vue
@@ -1,0 +1,285 @@
+<script setup lang="ts">
+import type { DisplayRow } from '../composables/useSavedRowResolver'
+import { computed } from 'vue'
+import { useLinkBookmarks } from '../composables/linkBookmarks'
+import { sanitizeRichHtml } from '../composables/sanitize'
+import { useSavedRowResolver } from '../composables/useSavedRowResolver'
+
+const { remove } = useLinkBookmarks()
+const { displayRows, loading, ready } = useSavedRowResolver()
+
+const PAGE_LABELS: Record<string, string> = {
+  '/video': 'Movies / TV / Anime',
+  '/audio': 'Music / Podcasts / Radio',
+  '/gaming': 'Gaming / Emulation',
+  '/reading': 'Books / Comics / Manga',
+  '/privacy': 'Adblocking / Privacy',
+  '/ai': 'Artificial Intelligence',
+  '/downloading': 'Downloading',
+  '/torrenting': 'Torrenting',
+  '/mobile': 'Android / iOS',
+  '/linux-macos': 'Linux / macOS',
+  '/misc': 'Miscellaneous'
+}
+
+const groupedRows = computed(() => {
+  const groups = new Map<string, DisplayRow[]>()
+
+  for (const row of displayRows.value) {
+    const key = row.page || '/'
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(row)
+  }
+
+  return [...groups.entries()].map(([page, rows]) => ({
+    page,
+    label: PAGE_LABELS[page] || page.replace(/^\//, '').replace(/-/g, ' '),
+    rows
+  }))
+})
+
+const rowHtml = (row: DisplayRow) => sanitizeRichHtml(row.html)
+
+const rowClasses = (row: DisplayRow) =>
+  [
+    'fmhy-saved-item',
+    row.status === 'missing' ? 'fmhy-saved-item--missing' : '',
+    ...row.classes.split(/\s+/).filter(Boolean)
+  ].filter(Boolean)
+
+const showLoader = computed(() => !ready.value || loading.value)
+</script>
+
+<template>
+  <div class="fmhy-saved-list">
+    <h1 class="flex items-center gap-2">
+      <span class="i-twemoji:bookmark" aria-hidden="true" />
+      My List
+    </h1>
+    <p class="fmhy-saved-intro">Your saved wiki entries.</p>
+
+    <div
+      v-if="showLoader"
+      class="fmhy-saved-loading"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div class="fmhy-saved-loading-head">
+        <span class="fmhy-saved-spinner" aria-hidden="true" />
+        <span class="fmhy-saved-loading-text">Loading saved entries…</span>
+      </div>
+      <div class="fmhy-saved-skeleton" aria-hidden="true">
+        <div class="fmhy-saved-skeleton-title" />
+        <div class="fmhy-saved-skeleton-line" />
+        <div class="fmhy-saved-skeleton-line" />
+        <div class="fmhy-saved-skeleton-line fmhy-saved-skeleton-line--short" />
+      </div>
+    </div>
+
+    <p v-else-if="displayRows.length === 0" class="fmhy-saved-empty">
+      Nothing saved yet. Hover a link on any wiki page and click
+      <strong>Bookmark</strong>
+      .
+    </p>
+
+    <section
+      v-for="group in groupedRows"
+      v-else
+      :key="group.page"
+      class="fmhy-saved-group"
+    >
+      <h2 class="fmhy-saved-group-title">
+        <a :href="group.page">{{ group.label }}</a>
+      </h2>
+
+      <ul>
+        <li v-for="row in group.rows" :key="row.url" :class="rowClasses(row)">
+          <span class="fmhy-saved-item-content" v-html="rowHtml(row)" />
+          <span
+            v-if="row.status === 'missing'"
+            class="fmhy-saved-status fmhy-saved-status--missing"
+            title="This entry was removed from the wiki"
+          >
+            removed
+          </span>
+          <button
+            type="button"
+            class="fmhy-saved-remove"
+            aria-label="Remove from My List"
+            @click="remove(row.url)"
+          >
+            <span class="i-lucide:x shrink-0 w-3.5 h-3.5" aria-hidden="true" />
+          </button>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.fmhy-saved-list {
+  max-width: 100%;
+}
+
+.fmhy-saved-intro {
+  color: var(--vp-c-text-2);
+  margin: 0 0 1.5rem;
+}
+
+.fmhy-saved-loading {
+  padding: 1.25rem;
+  border: 2px dashed var(--vp-c-divider);
+  border-radius: 0.75rem;
+  background: var(--vp-c-bg-soft);
+}
+
+.fmhy-saved-loading-head {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-bottom: 1rem;
+}
+
+.fmhy-saved-loading-text {
+  color: var(--vp-c-text-2);
+  font-size: 0.95rem;
+}
+
+.fmhy-saved-spinner {
+  display: block;
+  flex-shrink: 0;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 2px solid var(--vp-c-divider);
+  border-top-color: var(--vp-c-brand-1);
+  border-radius: 50%;
+  animation: fmhy-saved-spin 0.65s linear infinite;
+}
+
+.fmhy-saved-skeleton {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.fmhy-saved-skeleton-title,
+.fmhy-saved-skeleton-line {
+  height: 0.85rem;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--vp-c-text-3) 12%, var(--vp-c-bg-alt)) 0%,
+    color-mix(in srgb, var(--vp-c-text-3) 22%, var(--vp-c-bg-alt)) 50%,
+    color-mix(in srgb, var(--vp-c-text-3) 12%, var(--vp-c-bg-alt)) 100%
+  );
+  background-size: 200% 100%;
+  animation: fmhy-saved-shimmer 1.4s ease-in-out infinite;
+}
+
+.fmhy-saved-skeleton-title {
+  width: 38%;
+  height: 1rem;
+}
+
+.fmhy-saved-skeleton-line--short {
+  width: 72%;
+}
+
+.fmhy-saved-empty {
+  color: var(--vp-c-text-2);
+  padding: 1.25rem;
+  border: 2px dashed var(--vp-c-divider);
+  border-radius: 0.75rem;
+  background: var(--vp-c-bg-soft);
+}
+
+@keyframes fmhy-saved-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fmhy-saved-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.fmhy-saved-group + .fmhy-saved-group {
+  margin-top: 2rem;
+}
+
+.fmhy-saved-group-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.fmhy-saved-group-title a {
+  color: var(--vp-c-text-1);
+  text-decoration: none;
+}
+
+.fmhy-saved-group-title a:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.fmhy-saved-item {
+  position: relative;
+}
+
+.fmhy-saved-item-content {
+  display: inline;
+}
+
+.fmhy-saved-status {
+  margin-left: 0.35rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--vp-c-text-3);
+  vertical-align: middle;
+}
+
+.fmhy-saved-status--missing {
+  color: var(--vp-c-warning-1, #e7a006);
+}
+
+.fmhy-saved-remove {
+  position: absolute;
+  right: 0;
+  top: 0.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: none;
+  border-radius: 0.35rem;
+  background: transparent;
+  color: var(--vp-c-text-3);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.fmhy-saved-item:hover .fmhy-saved-remove,
+.fmhy-saved-remove:focus-visible {
+  opacity: 1;
+}
+
+.fmhy-saved-remove:hover,
+.fmhy-saved-remove:focus-visible {
+  color: var(--vp-c-brand-1);
+  background: color-mix(in srgb, var(--vp-c-brand-1) 8%, var(--vp-c-bg-alt));
+}
+</style>

--- a/docs/.vitepress/theme/composables/linkBookmarks.ts
+++ b/docs/.vitepress/theme/composables/linkBookmarks.ts
@@ -1,0 +1,100 @@
+import { useLocalStorage } from '@vueuse/core'
+import { normalizeBookmarkUrl, normalizePagePath } from './savedRowUtils'
+
+export type SavedBookmark = {
+  url: string
+  page: string
+  savedAt: number
+  html?: string
+  classes?: string
+}
+
+const STORAGE_KEY = 'fmhy-saved-links'
+
+const bookmarks = useLocalStorage<SavedBookmark[]>(STORAGE_KEY, [])
+
+function migrateLegacy(
+  entry: SavedBookmark & {
+    title?: string
+    section?: string
+  }
+): SavedBookmark {
+  const migrated: SavedBookmark = {
+    url: normalizeBookmarkUrl(entry.url),
+    page: normalizePagePath(entry.page),
+    savedAt: entry.savedAt
+  }
+
+  if (entry.html) {
+    migrated.html = entry.html
+    migrated.classes = entry.classes || ''
+  } else if (entry.title) {
+    const title = entry.title || migrated.url
+    migrated.html = `<strong><a href="${migrated.url}">${title}</a></strong>`
+    migrated.classes = entry.classes || ''
+  }
+
+  return migrated
+}
+
+export function useLinkBookmarks() {
+  const rows = bookmarks
+
+  const normalized = () => rows.value.map((entry) => migrateLegacy(entry))
+
+  const isBookmarked = (url: string) => {
+    const target = normalizeBookmarkUrl(url)
+    return normalized().some(
+      (entry) => normalizeBookmarkUrl(entry.url) === target
+    )
+  }
+
+  const toggle = (bookmark: Omit<SavedBookmark, 'savedAt'>) => {
+    const url = normalizeBookmarkUrl(bookmark.url)
+    const page = normalizePagePath(bookmark.page)
+    const index = rows.value.findIndex(
+      (entry) => normalizeBookmarkUrl(entry.url) === url
+    )
+    if (index >= 0) {
+      rows.value.splice(index, 1)
+      return false
+    }
+
+    rows.value.push({ ...bookmark, url, page, savedAt: Date.now() })
+    return true
+  }
+
+  const remove = (url: string) => {
+    const target = normalizeBookmarkUrl(url)
+    const index = rows.value.findIndex(
+      (entry) => normalizeBookmarkUrl(entry.url) === target
+    )
+    if (index >= 0) rows.value.splice(index, 1)
+  }
+
+  const updateSnapshot = (
+    url: string,
+    snapshot: Pick<SavedBookmark, 'html' | 'classes'>
+  ) => {
+    const target = normalizeBookmarkUrl(url)
+    const index = rows.value.findIndex(
+      (entry) => normalizeBookmarkUrl(entry.url) === target
+    )
+    if (index < 0 || !snapshot.html) return
+
+    rows.value[index] = {
+      ...rows.value[index],
+      html: snapshot.html,
+      classes: snapshot.classes || ''
+    }
+  }
+
+  return {
+    bookmarks: rows,
+    normalized,
+    isBookmarked,
+    toggle,
+    remove,
+    updateSnapshot
+  }
+}

--- a/docs/.vitepress/theme/composables/savedRowUtils.ts
+++ b/docs/.vitepress/theme/composables/savedRowUtils.ts
@@ -1,0 +1,128 @@
+export const LINK_SELECTOR = 'a[href*="://"]'
+
+export function normalizePagePath(page: string, base = '/') {
+  let path = page.trim()
+
+  try {
+    path = new URL(path, window.location.href).pathname
+  } catch {
+    path = path.split(/[?#]/)[0] || '/'
+  }
+
+  if (!path.startsWith('/')) path = `/${path}`
+  if (base && base !== '/' && path.startsWith(base)) {
+    path = path.slice(base.length) || '/'
+  }
+  path = path.replace(/\/index(?:\.html)?$/, '/').replace(/\.html$/, '')
+
+  return path.replace(/\/$/, '') || '/'
+}
+
+const EXCLUDED_ANCESTORS = [
+  '.fmhy-link-wrap',
+  '.link-card',
+  '.custom-block',
+  '.VPLocalSearchBox',
+  '.feedback-footer',
+  '.fmhy-saved-list'
+]
+
+export function normalizeBookmarkUrl(url: string): string {
+  try {
+    const parsed = new URL(url, window.location.href)
+    parsed.hash = ''
+    parsed.hostname = parsed.hostname.toLowerCase().replace(/^www\./, '')
+
+    if (parsed.pathname.length > 1 && parsed.pathname.endsWith('/')) {
+      parsed.pathname = parsed.pathname.slice(0, -1)
+    }
+
+    return parsed.href
+  } catch {
+    return url.trim()
+  }
+}
+
+export function bookmarkUrlsMatch(stored: string, candidate: string): boolean {
+  return normalizeBookmarkUrl(stored) === normalizeBookmarkUrl(candidate)
+}
+
+export function resolveLinkHref(link: HTMLAnchorElement): string {
+  const attr = link.getAttribute('href')?.trim()
+  if (!attr) return link.href
+
+  try {
+    return new URL(attr, window.location.href).href
+  } catch {
+    return link.href
+  }
+}
+
+export function isEligibleLink(link: HTMLAnchorElement) {
+  if (link.closest('.fmhy-link-wrap')) return false
+  if (EXCLUDED_ANCESTORS.some((selector) => link.closest(selector)))
+    return false
+  if (!link.textContent?.trim()) return false
+
+  const href = link.getAttribute('href') || ''
+  return /^https?:\/\//i.test(href) || href.startsWith('//')
+}
+
+export function getMainLink(li: HTMLLIElement) {
+  for (const link of li.querySelectorAll<HTMLAnchorElement>('a[href]')) {
+    if (isEligibleLink(link)) return link
+  }
+  return null
+}
+
+export function captureRowHtml(li: HTMLLIElement): string {
+  const clone = li.cloneNode(true) as HTMLLIElement
+
+  clone.querySelectorAll('.fmhy-bookmark-tooltip').forEach((el) => el.remove())
+  clone.querySelectorAll('.fmhy-link-wrap').forEach((wrap) => {
+    const parent = wrap.parentNode
+    if (!parent) return
+
+    while (wrap.firstChild) parent.insertBefore(wrap.firstChild, wrap)
+    parent.removeChild(wrap)
+  })
+
+  return clone.innerHTML.trim()
+}
+
+export function extractRowFromLi(li: HTMLLIElement) {
+  return {
+    html: captureRowHtml(li),
+    classes: li.className.replace(/\bfmhy-saved-item\b/g, '').trim()
+  }
+}
+
+export function buildPageRowMap(root: ParentNode) {
+  const map = new Map<string, ReturnType<typeof extractRowFromLi>>()
+
+  root.querySelectorAll<HTMLLIElement>('li').forEach((li) => {
+    const link = getMainLink(li)
+    if (!link) return
+
+    const href = resolveLinkHref(link)
+    if (!href) return
+
+    map.set(normalizeBookmarkUrl(href), extractRowFromLi(li))
+  })
+
+  return map
+}
+
+export function findRowInMap(
+  map: Map<string, ReturnType<typeof extractRowFromLi>>,
+  url: string
+) {
+  const direct = map.get(normalizeBookmarkUrl(url))
+  if (direct) return direct
+
+  for (const [key, value] of map) {
+    if (bookmarkUrlsMatch(url, key)) return value
+  }
+
+  return null
+}

--- a/docs/.vitepress/theme/composables/savedRowUtils.ts
+++ b/docs/.vitepress/theme/composables/savedRowUtils.ts
@@ -78,7 +78,9 @@ export function getMainLink(li: HTMLLIElement) {
 export function captureRowHtml(li: HTMLLIElement): string {
   const clone = li.cloneNode(true) as HTMLLIElement
 
-  clone.querySelectorAll('.fmhy-bookmark-tooltip').forEach((el) => el.remove())
+  clone
+    .querySelectorAll('.fmhy-bookmark-tooltip, .fmhy-bookmark-inline')
+    .forEach((el) => el.remove())
   clone.querySelectorAll('.fmhy-link-wrap').forEach((wrap) => {
     const parent = wrap.parentNode
     if (!parent) return

--- a/docs/.vitepress/theme/composables/useSavedRowResolver.ts
+++ b/docs/.vitepress/theme/composables/useSavedRowResolver.ts
@@ -1,0 +1,297 @@
+import type { App, Component, Ref } from 'vue'
+import type { SavedBookmark } from './linkBookmarks'
+import { dataSymbol } from 'vitepress'
+import { pathToFile } from 'vitepress/dist/client/app/utils'
+import { useData } from 'vitepress/dist/client/theme-default/composables/data'
+import {
+  computed,
+  createApp,
+  h,
+  nextTick,
+  onMounted,
+  ref,
+  shallowRef,
+  watch
+} from 'vue'
+import GradientCard from '../components/GradientCard.vue'
+import LinkCard from '../components/LinkCard.vue'
+import LinkInline from '../components/LinkInline.vue'
+import Tag from '../components/Tag.vue'
+import VideoFrame from '../components/VideoFrame.vue'
+import { useLinkBookmarks } from './linkBookmarks'
+import {
+  buildPageRowMap,
+  findRowInMap,
+  normalizeBookmarkUrl,
+  normalizePagePath
+} from './savedRowUtils'
+
+export { normalizePagePath }
+
+export type DisplayRow = SavedBookmark & {
+  html: string
+  classes: string
+  status: 'live' | 'missing'
+}
+
+export type RowData = { html: string; classes: string }
+
+const pageRowCache = new Map<string, Map<string, RowData>>()
+
+const ComponentStub = {
+  render: () => null
+}
+
+const VDropdownStub = {
+  name: 'VDropdown',
+  render(this: { $slots: { default?: () => unknown } }) {
+    return h('span', { class: 'v-popper' }, this.$slots.default?.())
+  }
+}
+
+interface ComponentModule {
+  default?: unknown
+  __pageData?: {
+    frontmatter?: Record<string, unknown>
+    relativePath?: string
+    title?: string
+  }
+  render?: unknown
+  setup?: unknown
+}
+
+interface VitePressData {
+  frontmatter: Ref<Record<string, unknown>>
+  page: Ref<{ params?: unknown; relativePath?: string; title?: string }>
+  site: Ref<{ base: string }>
+}
+
+export function rememberPageRow(
+  page: string,
+  base: string,
+  url: string,
+  row: RowData
+) {
+  const pagePath = normalizePagePath(page, base)
+  const map = pageRowCache.get(pagePath) || new Map<string, RowData>()
+  map.set(normalizeBookmarkUrl(url), row)
+  pageRowCache.set(pagePath, map)
+}
+
+function createPageData(
+  vitePressData: VitePressData,
+  pageModule: ComponentModule['__pageData']
+) {
+  return {
+    ...vitePressData,
+    frontmatter: computed(() => ({
+      ...vitePressData.frontmatter.value,
+      ...(pageModule?.frontmatter || {})
+    })),
+    page: computed(() => ({
+      ...vitePressData.page.value,
+      relativePath: pageModule?.relativePath,
+      title: pageModule?.title
+    }))
+  }
+}
+
+async function loadPageRowMap(
+  page: string,
+  vitePressData: VitePressData
+): Promise<Map<string, RowData>> {
+  const pagePath = normalizePagePath(page, vitePressData.site.value.base)
+  const cached = pageRowCache.get(pagePath)
+  if (cached?.size) return cached
+
+  const file = pathToFile(pagePath)
+  if (!file) return new Map()
+
+  const map = await loadPageRowMapFromModule(file, vitePressData)
+  if (map.size === 0) {
+    const fetchedMap = await loadPageRowMapFromHtml(
+      pagePath,
+      vitePressData.site.value.base
+    )
+    if (fetchedMap.size > 0) {
+      pageRowCache.set(pagePath, fetchedMap)
+      return fetchedMap
+    }
+  }
+
+  if (map.size > 0) pageRowCache.set(pagePath, map)
+  return map
+}
+
+async function loadPageRowMapFromHtml(pagePath: string, base: string) {
+  const url = `${base.replace(/\/$/, '')}${pagePath || '/'}`
+
+  try {
+    const response = await fetch(url)
+    if (!response.ok) return new Map<string, RowData>()
+
+    const html = await response.text()
+    const doc = new DOMParser().parseFromString(html, 'text/html')
+    const root = doc.querySelector('.VPDoc .content-container .vp-doc')
+
+    return root ? buildPageRowMap(root) : new Map<string, RowData>()
+  } catch {
+    return new Map<string, RowData>()
+  }
+}
+
+async function loadPageRowMapFromModule(
+  file: string,
+  vitePressData: VitePressData
+): Promise<Map<string, RowData>> {
+  let host: HTMLDivElement | null = null
+  let app: App | null = null
+
+  try {
+    const mod = (await import(/* @vite-ignore */ file)) as ComponentModule
+    const comp = (mod.default ?? mod) as Component
+    if (
+      !comp ||
+      typeof comp !== 'object' ||
+      (!('render' in comp) && !('setup' in comp))
+    ) {
+      return new Map()
+    }
+
+    const pageData = createPageData(vitePressData, mod.__pageData)
+    app = createApp(comp)
+    app.component('Feedback', ComponentStub)
+    app.component('VDropdown', VDropdownStub)
+    app.component('Tooltip', ComponentStub)
+    app.component('GradientCard', GradientCard)
+    app.component('VideoFrame', VideoFrame)
+    app.component('LinkCard', LinkCard)
+    app.component('LinkInline', LinkInline)
+    app.component('Tag', Tag)
+    app.config.warnHandler = () => {}
+    app.provide(dataSymbol, pageData)
+    Object.defineProperties(app.config.globalProperties, {
+      $frontmatter: {
+        get() {
+          return pageData.frontmatter.value
+        }
+      },
+      $params: {
+        get() {
+          return pageData.page.value.params
+        }
+      }
+    })
+
+    host = document.createElement('div')
+    host.className = 'vp-doc fmhy-row-resolve-host'
+    host.style.cssText =
+      'position:fixed;left:-10000px;top:0;width:900px;visibility:hidden;pointer-events:none'
+    document.body.appendChild(host)
+    app.mount(host)
+
+    await nextTick()
+    await nextTick()
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    return buildPageRowMap(host)
+  } catch {
+    return new Map()
+  } finally {
+    app?.unmount()
+    host?.remove()
+  }
+}
+
+function resolveDisplayRow(
+  bookmark: SavedBookmark,
+  pageMaps: Map<string, Map<string, RowData>>,
+  pagePath: string
+): DisplayRow {
+  const map = pageMaps.get(pagePath) || new Map()
+  const live = findRowInMap(map, bookmark.url)
+  const pageLoaded = map.size > 0
+
+  if (live) {
+    return {
+      ...bookmark,
+      html: live.html,
+      classes: live.classes,
+      status: 'live'
+    }
+  }
+
+  if (bookmark.html) {
+    return {
+      ...bookmark,
+      html: bookmark.html,
+      classes: bookmark.classes || '',
+      status: pageLoaded ? 'missing' : 'live'
+    }
+  }
+
+  return {
+    ...bookmark,
+    html: `<a href="${bookmark.url}">${bookmark.url}</a>`,
+    classes: '',
+    status: pageLoaded ? 'missing' : 'live'
+  }
+}
+
+export function useSavedRowResolver() {
+  const { normalized, bookmarks } = useLinkBookmarks()
+  const vitePressData = useData() as VitePressData
+  const loading = ref(true)
+  const ready = ref(false)
+  const displayRows = shallowRef<DisplayRow[]>([])
+
+  let resolveVersion = 0
+
+  async function resolveRows() {
+    const version = ++resolveVersion
+    loading.value = true
+
+    const saved = normalized()
+    if (saved.length === 0) {
+      displayRows.value = []
+      loading.value = false
+      ready.value = true
+      return
+    }
+
+    const base = vitePressData.site.value.base
+    const pages = [
+      ...new Set(saved.map((entry) => normalizePagePath(entry.page, base)))
+    ]
+    const pageMaps = new Map<string, Map<string, RowData>>()
+
+    await Promise.all(
+      pages.map(async (pagePath) => {
+        const map = await loadPageRowMap(pagePath, vitePressData)
+        if (version !== resolveVersion) return
+        pageMaps.set(pagePath, map)
+      })
+    )
+
+    if (version !== resolveVersion) return
+
+    displayRows.value = saved
+      .map((bookmark) =>
+        resolveDisplayRow(
+          bookmark,
+          pageMaps,
+          normalizePagePath(bookmark.page, base)
+        )
+      )
+      .sort((a, b) => b.savedAt - a.savedAt)
+
+    loading.value = false
+    ready.value = true
+  }
+
+  onMounted(() => resolveRows())
+
+  watch(bookmarks, () => resolveRows(), { deep: true })
+
+  return { displayRows, loading, ready, refresh: resolveRows }
+}

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -200,6 +200,66 @@ html {
   color: var(--vp-c-brand-1);
 }
 
+.link-bookmark-icon {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 0.85rem;
+  height: 0.85rem;
+  background-color: currentColor;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+}
+
+.link-bookmark-btn.is-saved .link-bookmark-icon {
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='black' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+}
+
+.link-bookmark-btn--inline .link-bookmark-icon {
+  width: 1.3em;
+  height: 1.3em;
+}
+
+.fmhy-bookmark-inline {
+  display: none;
+}
+
+@media (hover: none) {
+  .fmhy-bookmark-tooltip {
+    display: none !important;
+  }
+
+  .fmhy-bookmark-inline {
+    display: inline;
+    white-space: nowrap;
+  }
+
+  .link-bookmark-btn--inline {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    color: var(--vp-c-text-3);
+    vertical-align: -0.24em;
+    width: 1.5em;
+    height: 1.5em;
+    line-height: 1;
+  }
+
+  .link-bookmark-btn--inline.is-saved {
+    color: var(--vp-c-brand-1);
+  }
+
+  .link-bookmark-btn--inline:active {
+    color: var(--vp-c-brand-1);
+  }
+}
+
 .fmhy-saved-page {
   padding-bottom: 2rem;
 }

--- a/docs/.vitepress/theme/style.scss
+++ b/docs/.vitepress/theme/style.scss
@@ -130,6 +130,80 @@ html {
   }
 }
 
+.fmhy-link-wrap {
+  position: relative;
+  display: inline;
+  white-space: inherit;
+}
+
+.fmhy-bookmark-tooltip {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  z-index: 10;
+  transform: translateX(-50%);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.15s ease,
+    visibility 0.15s ease;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: -0.5rem;
+    right: -0.5rem;
+    top: 100%;
+    height: 0.75rem;
+  }
+}
+
+@media (hover: hover) {
+  .fmhy-link-wrap:hover .fmhy-bookmark-tooltip,
+  .fmhy-bookmark-tooltip:hover {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+}
+
+.link-bookmark-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  border: 2px solid var(--vp-c-divider);
+  border-radius: 0.5rem;
+  background: var(--vp-c-bg-alt);
+  color: var(--vp-c-text-2);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  box-shadow: var(--vp-shadow-2);
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.link-bookmark-btn:hover,
+.link-bookmark-btn:focus-visible {
+  color: var(--vp-c-brand-1);
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 35%, var(--vp-c-divider));
+  background-color: color-mix(in srgb, var(--vp-c-brand-1) 6%, var(--vp-c-bg-alt));
+}
+
+.link-bookmark-btn.is-saved {
+  color: var(--vp-c-brand-1);
+}
+
+.fmhy-saved-page {
+  padding-bottom: 2rem;
+}
+
 .vp-doc .custom-block a {
   text-decoration: underline;
   text-underline-offset: 4px;

--- a/docs/.vitepress/transformer/constants.ts
+++ b/docs/.vitepress/transformer/constants.ts
@@ -144,7 +144,8 @@ export const excluded = [
   'feedback.md',
   'index.md',
   'sandbox.md',
-  'startpage.md'
+  'startpage.md',
+  'my-list.md'
 ]
 
 export function getHeader(id: string) {

--- a/docs/my-list.md
+++ b/docs/my-list.md
@@ -1,0 +1,19 @@
+---
+title: My List
+description: Your saved wiki entries.
+editLink: false
+outline: false
+next: false
+prev: false
+sidebar: true
+---
+
+<script setup>
+import MyList from './.vitepress/theme/components/MyList.vue'
+</script>
+
+<div class="vp-doc fmhy-saved-page">
+
+<MyList />
+
+</div>


### PR DESCRIPTION
<img width="589" height="133" alt="image" src="https://github.com/user-attachments/assets/8fcdcd26-de08-4b3c-abf8-bcbc028914a0" />
<img width="1600" height="640" alt="image" src="https://github.com/user-attachments/assets/ede9c2be-ee3f-486a-b035-a23ebdee1f65" />

I've been using FMHY as a reference and kept losing track of links I meant to come back to.

**How it works**: when you hover a link on any wiki page, a small Bookmark button shows up next to it. Click it and that row gets saved to localStorage.

When rendering My List, the app tries to re-fetch the live row from the original page so you see the current version with tags and formatting intact. If an entry was removed from the wiki, it falls back to the HTML snapshot saved at bookmark time and marks it as removed. You can also remove items from My List with the X button.

There's a "My List" link at the top of the sidebar. Bookmark buttons don't show on the My List page itself (would be weird to bookmark bookmarks).

This is a draft and I'm definitely open to feedback, naming, UX, where the button appears, whether sidebar placement is right, performance of loading saved pages in the background, all of it. Happy to adjust before this is ready to merge.
