### PR TITLE
fix blank previews for emoji headings

### DIFF
--- a/docs/.vitepress/constants.ts
+++ b/docs/.vitepress/constants.ts
@@ -210,11 +210,16 @@ export const search: DefaultTheme.Config['search'] = {
         ''
       )
 
-      // I do this as env.frontmatter is not available until I call `md.render`
-      if (contents.includes('Beginners Guide'))
-        contents = transformGuide(contents)
+      const isPostOrOther =
+        relativePath.includes('posts') || relativePath.includes('other')
 
-      contents = transform(contents)
+      if (!isPostOrOther) {
+        // I do this as env.frontmatter is not available until I call `md.render`
+        if (contents.includes('Beginners Guide'))
+          contents = transformGuide(contents)
+
+        contents = transform(contents)
+      }
       let html = md.render(contents, env)
       // Strip <Tooltip ...>...</Tooltip> contents to avoid indexing hidden notes in search
       html = html.replace(/<Tooltip[\s\S]*?<\/Tooltip>/gi, '')

--- a/docs/.vitepress/theme/components/VPLocalSearchBox.vue
+++ b/docs/.vitepress/theme/components/VPLocalSearchBox.vue
@@ -691,9 +691,7 @@ watch(
       if (canceled) return
 
       const mapped = candidates.map((r) => {
-        const [id, anchor] = r.id.split('#')
-        const map = cache.get(id)
-        const text = map?.get(anchor) ?? ''
+        const text = lookupExcerptText(r.id)
         return mapResult(r, text)
       })
 
@@ -720,9 +718,7 @@ watch(
       if (canceled) return
 
       const mapped = sliced.map((r) => {
-        const [id, anchor] = r.id.split('#')
-        const map = showDetailedListValue ? cache.get(id) : undefined
-        const text = map?.get(anchor) ?? ''
+        const text = showDetailedListValue ? lookupExcerptText(r.id) : ''
         return mapResult(r, text)
       })
 
@@ -967,6 +963,31 @@ function prevMatch(index: number) {
   }
 }
 
+function lookupExcerptText(resultId: string): string {
+  const hashIndex = resultId.indexOf('#')
+  if (hashIndex === -1) return ''
+  const pageId = resultId.slice(0, hashIndex)
+  const map = cache.get(pageId)
+  if (!map) return ''
+  const anchor = resultId.slice(hashIndex + 1)
+  const direct = map.get(anchor)
+  if (direct) return direct
+  // The search index (constants.ts) and the excerpt DOM derive heading slugs
+  // from two separate render passes that can disagree: e.g. an emoji in a
+  // heading is dropped from the index slug ("stars-added") but baked into the
+  // mounted component's slug ("stars-added-⭐"). Recover by matching the index
+  // anchor as a prefix of a DOM key — but only when exactly one key matches, so
+  // an ambiguous prefix never silently returns a sibling section's excerpt.
+  const prefix = anchor + '-'
+  let found: string | null = null
+  for (const [key, html] of map) {
+    if (!key.startsWith(prefix)) continue
+    if (found !== null) return ''
+    found = html
+  }
+  return found ?? ''
+}
+
 async function fetchExcerpt(id: string) {
   const hashIndex = id.indexOf('#')
   const cleanId = hashIndex === -1 ? id : id.slice(0, hashIndex)
@@ -1007,10 +1028,8 @@ async function processExcerpts(
     if (isCanceled()) return
     const hashIndex = id.indexOf('#')
     const mapId = hashIndex === -1 ? id : id.slice(0, hashIndex)
-    let map = cache.get(mapId)
-    if (map) continue
-    map = new Map()
-    cache.set(mapId, map)
+    if (cache.has(mapId)) continue
+    const map = new Map<string, string>()
     const comp = (mod.default ?? mod) as { render?: unknown; setup?: unknown }
     if (comp && typeof comp === 'object' && (comp.render || comp.setup)) {
       try {
@@ -1036,8 +1055,13 @@ async function processExcerpts(
         try {
           const headings = div.querySelectorAll('h1, h2, h3, h4, h5, h6')
           headings.forEach((heading) => {
+            // VitePress sets the heading's id and its anchor href to the same
+            // slug, so one key suffices; fall back to id if the anchor link is
+            // missing for any reason.
             const href = heading.querySelector('a')?.getAttribute('href')
-            const anchor = href?.startsWith('#') && href.slice(1)
+            const anchor = href?.startsWith('#')
+              ? href.slice(1)
+              : (heading.getAttribute('id') ?? undefined)
             if (!anchor) return
             let html = ''
             let next: Element | null = heading.nextElementSibling
@@ -1056,8 +1080,9 @@ async function processExcerpts(
               if (!isNoteBlock) html += next.outerHTML
               next = next.nextElementSibling
             }
-            map!.set(anchor, html)
+            map.set(anchor, html)
           })
+          cache.set(mapId, map)
         } finally {
           app.unmount()
         }


### PR DESCRIPTION
Detailed search results show no preview body for some sections, like "Stars Added ⭐" 

Preview: https://54c79645.edit-b69.pages.dev/

Root cause: the search index and the live page derive heading slugs from two different render passes. The page build (transformsPlugin) skips the markdown transform() for posts/other, but the search-index builder (_render) ran it unconditionally. transform() rewrites ⭐ → :star: → empty, so the index slugged # Stars Added ⭐ to stars-added while the live DOM anchor is stars-added-⭐. Excerpt lookup is keyed by the DOM anchor, so it missed which means you'd get a blank preview.

- `constants.ts` - gate the transformGuide/transform calls behind the same posts/other guard transformsPlugin uses, so the index processes each file identically to the page
- `VPLocalSearchBox.vue`
  - `lookupExcerptText()` - direct anchor lookup with a unique-prefix fallback as a backstop for any residual index↔DOM slug divergence (only resolves when exactly one DOM key matches, so it never returns a sibling section's excerpt).
  - `Cache-poisoning fix` - build the per-page excerpt map locally and only cache.set it after a successful mount + heading walk. Previously a transient dynamic-import failure cached an empty map permanently, blanking every preview on that page for the session.
  - Collapse the heading anchor to a single key (VitePress sets id and the anchor href to the same slug).

Two other PRs were made for the same problem, but I made my own 
- #5563 (manuJL) - same fix, but his PR touches unrelated files and is conflicted, so I thought it would be easier to make my own. I also added a unique-match fallback
- #5631 (Sarkar) - fixed at the lookup layer (alias storage + prefix fallback). My PR keeps the prefix-fallback idea but with a unique-match guard (avoids serving the wrong section's excerpt) and drops the decodeURIComponent normalization and id/href alias duplication, which are no-ops on this site: index anchors are stored raw (never percent-encoded), and VitePress always sets id === href.

Before: 
<img width="918" height="422" alt="image" src="https://github.com/user-attachments/assets/8d6e1690-4eeb-45f1-bfb1-a9e558dda161" />

After:
<img width="908" height="558" alt="image" src="https://github.com/user-attachments/assets/c0dd7f77-5f3e-4e5e-b65b-3bd81baacc2e" />

Main Credit to manuJL for finding the main solution.