### PR TITLE
Add Emcognito, EchoThread and Siftfy

### DIFF
--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -295,6 +295,7 @@
 * [cf-workers-telegram-bot](https://github.com/codebam/cf-workers-telegram-bot) - Serverless Telegram Bot / [GitHub](https://github.com/codebam/cf-workers-telegram-bot)
 * [Plaid](https://plaid.com/) - Financial Account API / [GitHub](https://github.com/plaid)
 * [PDF Bot](https://github.com/esbenp/pdf-bot) - A Node queue API for generating PDFs
+* [Siftfy](https://siftfy.io/) - Spam Detection API / 10K Requests Monthly
 
 ***
 
@@ -768,7 +769,7 @@
 * [Directory Lister](https://directorylister.com/) - Web-Based Directory Listing
 * [BawkBox](https://bawkbox.com/) - Website Widgets
 * [The SSO Wall of Shame](https://sso.tax/) - Vendors without Built-in SSO
-* [Disfora](https://disfora.com/), [Remarkbox](https://www.remarkbox.com/) or [HTML Comment Box](https://www.htmlcommentbox.com/) - Site Comment Systems
+* [Disfora](https://disfora.com/), [Remarkbox](https://www.remarkbox.com/), [HTML Comment Box](https://www.htmlcommentbox.com/) or [EchoThread](https://echothread.io/) - Site Comment Systems
 * [Can I Email?](https://www.caniemail.com/) - Email Functionality Check
 * [Typebot](https://typebot.io/) - Embedded Chat App
 * [uMap](https://umap-project.org/) - Custom Embeddable Maps for Websites / [GitHub](https://github.com/umap-project/umap/)

--- a/docs/internet-tools.md
+++ b/docs/internet-tools.md
@@ -517,6 +517,7 @@
 * [SimpleLogin](https://simplelogin.io/) - 10 Shared / No Catch-All / [Send Email](https://simplelogin.io/docs/getting-started/send-email/) / [X](https://x.com/SimpleLogin) / [Subreddit](https://www.reddit.com/r/Simplelogin/) / [GitHub](https://github.com/simple-login/app)
 * [AdGuard Mail](https://adguard-mail.com/) - 10 Shared / 2K Forwards Monthly / No Catch-All
 * [Firefox Relay](https://relay.firefox.com/) - 50 Shared / No Catch-All
+* [Emcognito](https://emcognito.com/) - Unlimited Shared / 100 Forwards Monthly / Passkey Login
 * [addy.io](https://addy.io/) - 10 Shared / 10MB Monthly Bandwidth / Catch-All / [GitHub](https://github.com/anonaddy/anonaddy)
 * [erine.email](https://erine.email/) - No Shared / Catch-All
 * [33mail](https://33mail.com/) - No Shared / 10MB Monthly Bandwidth / Catch-All


### PR DESCRIPTION
Adding three free tools. **Disclosure: I'm the maintainer of all three** — flagging that up front per the contributing guidance to include relevant context. Each has a genuinely free (not trial) tier, and I've matched the existing entry format in each section.

### Email Aliasing (`internet-tools.md`)
- **[Emcognito](https://emcognito.com/)** — Unlimited shared aliases, 100 forwards/month on the free tier, passkey login, no credit card. Sits alongside SimpleLogin / addy.io / Firefox Relay.

### Site Comment Systems (`developer-tools.md`)
- **[EchoThread](https://echothread.io/)** — Privacy-first embedded comment platform (Disqus alternative). Free Hobby tier forever (1 site, 10k monthly views, 1k comments), no ads, no cross-site tracking. Added to the existing Disfora / Remarkbox / HTML Comment Box line.

### API Tools (`developer-tools.md`)
- **[Siftfy](https://siftfy.io/)** — Spam-detection API returning a calibrated probability score. Free tier 10k requests/month, no credit card.

All links verified working. Happy to adjust wording, ordering, or split into separate PRs if preferred.