### PR TITLE
Add CS2 News to Counter-Strike tools

### DIFF
--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -1045,6 +1045,7 @@
 * [CS2 Weapon Spreadsheet](https://docs.google.com/spreadsheets/d/11tDzUNBq9zIX6_9Rel__fdAUezAQzSnh5AVYzCP060c/) - Weapon Stats / Prices
 * [ArminC-AutoExec](https://github.com/ArmynC/ArminC-AutoExec) - ArminC's CS2 Config
 * [CS2 Browser](https://cs2browser.net/) or [CS2 Server Picker](https://github.com/FN-FAL113/cs2-server-picker) - Counter-Strike 2 Server Browser
+* [CS2 News](https://cs2news.gg/) - Counter-Strike 2 news and update tracker.
 
 ***
 


### PR DESCRIPTION
Added CS2 News as a Counter-Strike 2 update and news tracker.