### PR TITLE
Auto-add labels to PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/.vitepress/**"
+          - "pests-repellent/**"
+          - "scripts/**"
+          - "api/**"
+          - "*"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**/*.md"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
I noticed the labels in Github PRs weren't being used. So I added a workflow that auto-detects whether it's a core change to the codebase or just a wiki edit. Then it'll auto-label it accordingly. 
Just thought it would be nice to have.