### PR TITLE
Add Stillgrid to Puzzle Games

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -490,6 +490,7 @@
 * [Puzzle Party](https://artsandculture.google.com/experiment/puzzle-party/EwGBPZlIzv0KRw) - Multiplayer Jigsaws
 * [PuzzlePrime](https://www.puzzleprime.com/) - Problems / Puzzles
 * [Game for the Brain](https://www.gamesforthebrain.com/) - Puzzles / Quizzes
+* [Stillgrid](https://stillgrid.app) - Sudoku Variants / Graded Difficulty / Open Source
 * [MasasGames](https://masasgames.com/) - Virtual Escape Rooms
 * [⁠Murdoku](https://murdoku.com/play/) - Weekly Murder Mystery Puzzles / [Discord](https://discord.com/invite/frYbdPpkSH)
 * [Murdle](https://murdle.com/) - Daily Murder Mystery


### PR DESCRIPTION
Adds [Stillgrid](https://stillgrid.app) to the Puzzle Games section of gaming.md.

Free multi-variant sudoku site: classic / X / jigsaw / killer at 6×6–16×16, difficulty graded by the solving techniques each puzzle actually requires. No ads, no signup to play, open source (MIT — https://github.com/renegadecitizen/stillgrid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)