### PR TITLE
Add feedback blocklist to prevent toxic messages and spam of profanity-

### DIFF
--- a/api/feedback-blocklist.txt
+++ b/api/feedback-blocklist.txt
@@ -1,0 +1,57 @@
+# FMHY Feedback Blocklist
+# One word/pattern per line. Lines starting with # are ignored.
+# These are checked server-side; toxic feedback is silently discarded
+# and never reaches Discord.
+
+# Racial slurs
+nigger
+nigga
+n1gger
+n1gga
+faggot
+fag
+faggit
+fagg0t
+tranny
+spic
+sp1c
+chink
+ch1nk
+kike
+k1ke
+coon
+c00n
+wetback
+gook
+kaffir
+darkie
+
+# Gender/sexist slurs
+bitch
+b1tch
+betch
+whore
+slut
+slutt
+cunt
+c0nt
+
+# General insults
+retard
+r3tard
+retarded
+dumbass
+dumb@ss
+
+# Severe profanity
+fuck
+fck
+fuk
+phuck
+sh1t
+asshole
+a$$hole
+
+# Homophobic slurs
+dyke
+lezbo

--- a/api/feedback-blocklist.txt
+++ b/api/feedback-blocklist.txt
@@ -1,57 +1,278 @@
 # FMHY Feedback Blocklist
-# One word/pattern per line. Lines starting with # are ignored.
-# These are checked server-side; toxic feedback is silently discarded
-# and never reaches Discord.
+# One word/phrase per line. Lines starting with # are comments (ignored).
+# These are checked server-side before sending to Discord.
+# Toxic feedback is silently discarded — the sender still sees "Sent".
+# Generated from: https://github.com/dsojevic/profanity-list + manual curation
+# Last updated: 2026-07-08
 
-# Racial slurs
+# ─────────────────────────────────────────────
+# RACIAL SLURS
+# ─────────────────────────────────────────────
 nigger
+niggers
 nigga
+niggas
+niggah
+niggaz
 n1gger
 n1gga
-faggot
-fag
-faggit
-fagg0t
-tranny
-spic
-sp1c
-chink
-ch1nk
+n1gg3r
+nig
+nigs
+negro
+negros
 kike
+kikes
 k1ke
-coon
-c00n
-wetback
+k1kes
+spic
+spics
+sp1c
+sp1cs
+spick
+chink
+chinks
+ch1nk
 gook
-kaffir
+gooks
+wetback
+wetbacks
+coon
+coons
+c00n
+c00ns
+beaner
+beaners
+zipperhead
+towelhead
+sandnigger
+sandn1gger
+camel jockey
 darkie
+darkies
+jigaboo
+porch monkey
+sambo
+tar baby
+cracker
+honky
+redneck racist
+white trash
+jungle bunny
+cotton picker
+nig nog
+nignogs
+knigger
 
-# Gender/sexist slurs
+# ─────────────────────────────────────────────
+# HOMOPHOBIC / TRANSPHOBIC SLURS
+# ─────────────────────────────────────────────
+faggot
+faggots
+fagg0t
+fagg0ts
+faggit
+faggits
+fag
+fags
+f4g
+f4gg0t
+queer (slur context)
+dyke
+dykes
+tranny
+trannies
+tr4nny
+shemale
+shemales
+he-she
+ladyboy
+transfag
+lezbo
+lezbos
+lesbo
+lesbos
+homo
+homos
+h0mo
+sodomite
+sodomites
+poofter
+poof
+butt pirate
+fudge packer
+
+# ─────────────────────────────────────────────
+# SEXIST / MISOGYNISTIC SLURS
+# ─────────────────────────────────────────────
 bitch
+bitches
 b1tch
+b1tches
 betch
 whore
+whores
 slut
+sluts
 slutt
 cunt
+cunts
 c0nt
+c0nts
+skank
+skanks
+thot
+twat
+twats
+hoe (slur)
+hoes
+skeezer
 
-# General insults
+# ─────────────────────────────────────────────
+# ABLEIST SLURS
+# ─────────────────────────────────────────────
 retard
+retards
 r3tard
 retarded
-dumbass
-dumb@ss
+retarted
+spaz
+spazz
+mongoloid
+moron (slur)
+imbecile (slur)
+idiot (slur context)
 
-# Severe profanity
+# ─────────────────────────────────────────────
+# SEVERE PROFANITY
+# ─────────────────────────────────────────────
 fuck
+fucks
+fucked
+fucker
+fuckers
+fucking
 fck
 fuk
 phuck
+f u c k
+f*ck
+fvck
+f@ck
+wtf
+stfu
+motherfucker
+motherfuckers
+motherfucking
+mf
+mfker
+shit
+shits
+shitting
 sh1t
+$hit
+sht
+shithole
+shitholes
+ass
+asses
 asshole
+assholes
 a$$hole
+a$$
+@ss
+@$$
+arsehole
+arseholes
+bastard
+bastards
+b@stard
+son of a bitch
+sob
+dick
+dicks
+d1ck
+cock
+cocks
+c0ck
+penis (explicit)
+pussy (slur)
+p*ssy
+prick
+pricks
+jackass
+jackasses
+dumbass
+dumb@ss
+dumbasses
+dipshit
+dipshits
+fuckwit
+fuckwits
+wanker
+wankers
+tosser
+tossers
+bullshit
+bulls**t
+bs (explicit)
+piss
+pissed
+pissing
+pissoff
+goddamn
+goddammit
+goddam
+crap (mild — optional)
+hell (mild — optional)
+damn (mild — optional)
 
-# Homophobic slurs
-dyke
-lezbo
+# ─────────────────────────────────────────────
+# ANTISEMITIC / RELIGIOUS HATE
+# ─────────────────────────────────────────────
+kike
+hebe
+heeb
+yid
+yids
+hymie
+hymies
+rabbi slur
+
+# ─────────────────────────────────────────────
+# NAZI / WHITE SUPREMACIST TERMINOLOGY
+# ─────────────────────────────────────────────
+sieg heil
+heil hitler
+14 words
+1488
+88 (nazi context)
+white power
+white supremacy
+white genocide
+race war
+zyklon
+gas the jews
+
+# ─────────────────────────────────────────────
+# ADDITIONAL OFFENSIVE TERMS
+# ─────────────────────────────────────────────
+kill yourself
+kys
+go kill yourself
+kms (kill myself)
+rape
+raping
+rapist
+rapists
+pedophile
+pedophiles
+pedo
+pedo (slur)
+molest
+molester
+child abuse
+cp (explicit)
+gore
+snuff
+necro

--- a/api/routes/feedback.post.ts
+++ b/api/routes/feedback.post.ts
@@ -22,7 +22,7 @@ try {
   console.warn('[feedback-filter] Failed to load profanity list', e)
 }
 
-function buildRegex(items: any[]): RegExp | null {
+function buildRegex(items: any[], flags: string): RegExp | null {
   if (!items.length) return null
   const parts = items.map((p) => {
     return p.match
@@ -34,13 +34,19 @@ function buildRegex(items: any[]): RegExp | null {
       .join('|')
   })
   // We use word boundaries (\b) to prevent partial-match false positives
-  return new RegExp(`\\b(?:${parts.join('|')})\\b`, 'gi')
+  return new RegExp(`\\b(?:${parts.join('|')})\\b`, flags)
 }
 
-// Severity 3 and 4 -> Blocked completely
-const BLOCK_REGEX = buildRegex(profanityList.filter((p) => p.severity >= 3))
-// Severity 1 and 2 -> Censored with ****
-const CENSOR_REGEX = buildRegex(profanityList.filter((p) => p.severity < 3))
+// Severity 3 and 4 -> Blocked completely (no 'g' flag to prevent stateful .test() bugs)
+const BLOCK_REGEX = buildRegex(
+  profanityList.filter((p) => p.severity >= 3),
+  'i'
+)
+// Severity 1 and 2 -> Censored with **** ('g' flag required to replace all instances)
+const CENSOR_REGEX = buildRegex(
+  profanityList.filter((p) => p.severity < 3),
+  'gi'
+)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // DISCORD HELPERS

--- a/api/routes/feedback.post.ts
+++ b/api/routes/feedback.post.ts
@@ -1,196 +1,46 @@
 /**
- *  Copyright (c) 2026 ManuJL. Apache License 2.0.
+ *  Copyright (c) 2025 taskylizard. Apache License 2.0.
  *
  *  feedback.post.ts — Feedback ingestion endpoint with profanity/toxicity filtering.
- *
- *  Architecture:
- *    1. Blocklist layer   — exact-match words from feedback-blocklist.txt (loaded at startup)
- *    2. Regex layer       — pattern matching for common leet-speak & obfuscation variants
- *    3. Normalisation     — strip zero-width chars, homoglyphs, repeated chars, separators
- *
- *  Toxic messages are silently discarded; the caller still receives { status: 'ok' }
- *  to prevent trolls from knowing their messages are blocked.
- *
- *  Performance notes:
- *    - Blocklist is loaded ONCE at module initialisation (not per-request).
- *    - Regex patterns are compiled ONCE at module initialisation.
- *    - All checks run in <1 ms on typical feedback lengths.
  */
 
+import { createRequire } from 'module'
 import {
   FeedbackSchema,
   getFeedbackOption
 } from '../../docs/.vitepress/types/Feedback'
 
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
-
 // ─────────────────────────────────────────────────────────────────────────────
-// BLOCKLIST — loaded once at startup
+// PROFANITY FILTERING
 // ─────────────────────────────────────────────────────────────────────────────
 
-let _blocklist: string[] = []
-
-/**
- * Load words from feedback-blocklist.txt into memory.
- * Each non-empty, non-comment line becomes a blocked term.
- */
-function loadBlocklist(): void {
-  // Try several possible paths (dev vs Cloudflare Worker bundle)
-  const candidates = [
-    resolve('./feedback-blocklist.txt'),
-    resolve('./api/feedback-blocklist.txt'),
-    new URL('../../feedback-blocklist.txt', import.meta.url).pathname
-  ]
-
-  for (const candidate of candidates) {
-    try {
-      const content = readFileSync(candidate, 'utf-8')
-      _blocklist = content
-        .split('\n')
-        .map((line) => line.trim().toLowerCase())
-        .filter((line) => line.length > 0 && !line.startsWith('#'))
-      console.info(
-        `[feedback-filter] Loaded ${_blocklist.length} blocked terms from ${candidate}`
-      )
-      return
-    } catch {
-      // Try next candidate
-    }
-  }
-
-  // Non-fatal: log a warning but keep running
-  console.warn(
-    '[feedback-filter] feedback-blocklist.txt not found — blocklist filtering disabled'
-  )
+const require = createRequire(import.meta.url)
+let profanityList: any[] = []
+try {
+  profanityList = require('@dsojevic/profanity-list/en.json')
+} catch (e) {
+  console.warn('[feedback-filter] Failed to load profanity list', e)
 }
 
-loadBlocklist()
-
-// ─────────────────────────────────────────────────────────────────────────────
-// REGEX LAYER — hardcoded patterns for common obfuscation / leet-speak
-// These act as a second defense in case a word isn't in the blocklist.
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Core patterns built with permissive separators between letters so users
- * can't bypass with spaces, dots, dashes, underscores, or zero-width chars.
- *
- * The SEP character class allows: space, dash, dot, underscore, asterisk,
- * at-sign, zero-width joiner (U+200D), soft hyphen (U+00AD).
- */
-const SEP = '[\\s\\-._*@\u200d\u00ad]*'
-
-const CORE_PATTERNS: RegExp[] = [
-  // Racial slurs
-  new RegExp(`n${SEP}[i1!|]+${SEP}g${SEP}g${SEP}[e3]+${SEP}r`, 'i'),
-  new RegExp(`n${SEP}[i1!|]+${SEP}g${SEP}g${SEP}[a@]+`, 'i'),
-  new RegExp(`f${SEP}[a@]+${SEP}g${SEP}g${SEP}[o0]+${SEP}t`, 'i'),
-  new RegExp(`f${SEP}[a@]+${SEP}g${SEP}g${SEP}[i1]+t`, 'i'),
-  new RegExp(`k${SEP}[i1]+${SEP}k${SEP}[e3]+`, 'i'),
-  new RegExp(`sp${SEP}[i1]+${SEP}c+k?`, 'i'),
-  new RegExp(`ch${SEP}[i1]+${SEP}nk`, 'i'),
-  new RegExp(`g${SEP}[o0]+${SEP}[o0]+k`, 'i'),
-  new RegExp(`c${SEP}[o0]+${SEP}[o0]+n`, 'i'),
-  new RegExp(`w${SEP}[e3]+${SEP}t${SEP}b${SEP}[a@]+ck`, 'i'),
-
-  // Severe profanity
-  new RegExp(`f${SEP}[u*]+${SEP}c${SEP}k`, 'i'),
-  new RegExp(`sh${SEP}[i1!]+${SEP}t`, 'i'),
-  new RegExp(`[a@]${SEP}s${SEP}s${SEP}h${SEP}[o0]+${SEP}l${SEP}[e3]+`, 'i'),
-  new RegExp(`b${SEP}[i1!]+${SEP}t${SEP}ch`, 'i'),
-  new RegExp(`c${SEP}[u*]+${SEP}n${SEP}t`, 'i'),
-  new RegExp(`d${SEP}[i1!]+${SEP}ck`, 'i'),
-  new RegExp(`c${SEP}[o0]+${SEP}ck`, 'i'),
-
-  // Homophobic
-  new RegExp(`f${SEP}[a@]+${SEP}g(?:g${SEP}[o0]+t)?`, 'i'),
-  new RegExp(`tr${SEP}[a@]+nn${SEP}[y]+`, 'i'),
-
-  // Violence / self-harm (exact phrases)
-  /kill\s+your\s*self/i,
-  /\bkys\b/i,
-  /\bkms\b/i,
-
-  // Nazi / hate symbols
-  /sieg\s*heil/i,
-  /heil\s*hitler/i,
-  /\b1488\b/,
-  /white\s+power/i,
-  /gas\s+the\s+jews/i
-]
-
-// ─────────────────────────────────────────────────────────────────────────────
-// NORMALISATION HELPERS
-// ─────────────────────────────────────────────────────────────────────────────
-
-/** Common homoglyph / leet-speak substitutions */
-const HOMOGLYPHS: [RegExp, string][] = [
-  [/[àáâãäåāă]/gi, 'a'],
-  [/[èéêëēĕ]/gi, 'e'],
-  [/[ìíîïīĭ]/gi, 'i'],
-  [/[òóôõöōŏ]/gi, 'o'],
-  [/[ùúûüūŭ]/gi, 'u'],
-  [/[ýÿ]/gi, 'y'],
-  [/[ñ]/gi, 'n'],
-  [/[@]/g, 'a'],
-  [/[3]/g, 'e'],
-  [/[1!|]/g, 'i'],
-  [/[0]/g, 'o'],
-  [/[$]/g, 's'],
-  [/[+]/g, 't'],
-  // Zero-width / invisible chars
-  [/[\u200b\u200c\u200d\u00ad\u2060\ufeff]/g, '']
-]
-
-/** Collapse repeated characters (e.g. "fuuuuck" → "fuck") */
-const REPEATED_CHARS = /(.)\1{2,}/g
-
-/**
- * Normalise a string to defeat common obfuscation tricks:
- *  - homoglyphs (@ → a, 3 → e, 0 → o …)
- *  - invisible / zero-width characters
- *  - repeated characters (fuuuuck → fuck)
- */
-function normalise(text: string): string {
-  let s = text
-  for (const [pattern, replacement] of HOMOGLYPHS) {
-    s = s.replace(pattern, replacement)
-  }
-  return s.replace(REPEATED_CHARS, '$1$1')
+function buildRegex(items: any[]): RegExp | null {
+  if (!items.length) return null
+  const parts = items.map((p) => {
+    return p.match
+      .split('|')
+      .map((m: string) => {
+        // Escape regex chars except * (which we turn into +)
+        return m.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '+')
+      })
+      .join('|')
+  })
+  // We use word boundaries (\b) to prevent partial-match false positives
+  return new RegExp(`\\b(?:${parts.join('|')})\\b`, 'gi')
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// MAIN TOXICITY CHECK
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Returns true if `text` contains any blocked term from the blocklist OR
- * matches any of the compiled regex patterns.
- *
- * Both the original and normalised forms are checked so that neither
- * exact nor obfuscated inputs slip through.
- */
-function containsToxicContent(text: string): boolean {
-  if (!text) return false
-
-  const lower = text.toLowerCase()
-  const norm = normalise(lower)
-
-  // 1. Blocklist exact-word check (both original and normalised)
-  if (_blocklist.length > 0) {
-    for (const term of _blocklist) {
-      if (lower.includes(term) || norm.includes(term)) return true
-    }
-  }
-
-  // 2. Regex pattern layer (both original and normalised)
-  for (const pattern of CORE_PATTERNS) {
-    if (pattern.test(lower) || pattern.test(norm)) return true
-  }
-
-  return false
-}
+// Severity 3 and 4 -> Blocked completely
+const BLOCK_REGEX = buildRegex(profanityList.filter((p) => p.severity >= 3))
+// Severity 1 and 2 -> Censored with ****
+const CENSOR_REGEX = buildRegex(profanityList.filter((p) => p.severity < 3))
 
 // ─────────────────────────────────────────────────────────────────────────────
 // DISCORD HELPERS
@@ -212,23 +62,33 @@ export default defineEventHandler(async (event) => {
   )
 
   // ── Toxicity gate ──────────────────────────────────────────────────────────
-  // Check the message and optional heading. If either contains toxic content,
-  // silently return { status: 'ok' } without forwarding to Discord.
-  // The sender has NO indication that their message was dropped.
-  const isToxic =
-    containsToxicContent(message) ||
-    (heading != null && containsToxicContent(heading))
-
-  if (isToxic) {
+  // 1. Block highly toxic messages (Severity 3/4)
+  if (
+    BLOCK_REGEX &&
+    (BLOCK_REGEX.test(message) ||
+      (heading != null && BLOCK_REGEX.test(heading)))
+  ) {
     const ip =
       getHeader(event, 'cf-connecting-ip') ||
       getHeader(event, 'x-forwarded-for') ||
       'unknown'
     console.warn(
-      `[feedback-filter] Toxic message silently discarded — IP: ${ip} | page: ${page}`
+      `[feedback-filter] Toxic message blocked — IP: ${ip} | page: ${page}`
     )
-    // Return the same shape as a successful submission to fool the sender.
-    return { status: 'ok' }
+    throw createError({
+      statusCode: 400,
+      message: 'Failed to send feedback. Please try again.'
+    })
+  }
+
+  // 2. Censor mild profanity (Severity 1/2)
+  let finalMessage = message
+  let finalHeading = heading
+  if (CENSOR_REGEX) {
+    finalMessage = message.replace(CENSOR_REGEX, '****')
+    if (finalHeading != null) {
+      finalHeading = finalHeading.replace(CENSOR_REGEX, '****')
+    }
   }
 
   // ── Rate limiting ──────────────────────────────────────────────────────────
@@ -253,15 +113,15 @@ export default defineEventHandler(async (event) => {
     { name: 'Page', value: `[${page}](${pageURL})`, inline: true },
     {
       name: 'Message',
-      value: sanitizeForDiscord(message),
+      value: sanitizeForDiscord(finalMessage),
       inline: false
     }
   ]
 
-  if (heading) {
+  if (finalHeading) {
     fields.unshift({
       name: 'Section',
-      value: sanitizeForDiscord(heading),
+      value: sanitizeForDiscord(finalHeading),
       inline: true
     })
   }
@@ -287,7 +147,9 @@ export default defineEventHandler(async (event) => {
 
   if (!response.ok) {
     const body = await response.text().catch(() => 'Unknown error')
-    console.error(`[feedback] Discord webhook failed: ${response.status} — ${body}`)
+    console.error(
+      `[feedback] Discord webhook failed: ${response.status} — ${body}`
+    )
     throw createError({
       statusCode: 502,
       statusMessage: 'Failed to send feedback'

--- a/api/routes/feedback.post.ts
+++ b/api/routes/feedback.post.ts
@@ -1,17 +1,5 @@
 /**
- *  Copyright (c) 2025 taskylizard. Apache License 2.0.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *  Copyright (c) 2026 ManuJL. Apache License 2.0.
  */
 
 import {
@@ -19,123 +7,97 @@ import {
   getFeedbackOption
 } from '../../docs/.vitepress/types/Feedback'
 
-// --- Toxic content blocker ---
-// Regex patterns for slurs, insults, and severe profanity.
-// Kept inline because Cloudflare Workers have no fs access at runtime.
-const BLOCKED_PATTERNS: RegExp[] = [
-  /n[i1]g{2}[ae]r?|nagger/i,
-  /fagg?[o0]t|fag[^o]|fag$/i,
-  /tranny|tranz/i,
-  /sp[i1]c/i,
-  /ch[i1]nk/i,
-  /k[i1]ke/i,
-  /c[o0]{2}n/i,
-  /wetback/i,
-  /gook/i,
-  /kaffir/i,
-  /b[i1]tch|betch/i,
-  /wh[o0]re/i,
-  /sl[u0]t/i,
-  /c[u0]nt/i,
-  /r[e3]t[a@]rd/i,
-  /dumb[\s\-_]*ass/i,
-  /f[u0][cg]k|phuck|fck/i,
-  /asshole|a\$\$hole/i,
-  /dyke|lezbo/i,
-]
+import { readFileSync } from 'fs'
 
-function containsToxicContent(text: string): boolean {
-  if (!text) return false
-  return BLOCKED_PATTERNS.some((pattern) => pattern.test(text))
+// Load blocklist at startup
+let blocklist: string[] = [];
+
+function loadBlocklist() {
+  try {
+    const content = readFileSync('./feedback-blocklist.txt', 'utf-8');
+    blocklist = content
+    .split('\n')
+    .map(line => line.trim().toLowerCase())
+    .filter(line => line && !line.startsWith('#'));
+    console.log(`[feedback] Loaded ${blocklist.length} blocked terms`);
+  } catch (err) {
+    console.error('[feedback] Failed to load blocklist:', err);
+    blocklist = [];
+  }
 }
 
-/** Escape triple backticks so user input can't break the embed's code-block formatting. */
+// Load on first import
+loadBlocklist();
+
+function containsToxicContent(text: string): boolean {
+  if (!text || blocklist.length === 0) return false;
+  const lower = text.toLowerCase();
+  return blocklist.some(word => lower.includes(word));
+}
+
+/** Escape triple backticks */
 function sanitizeForDiscord(input: string): string {
-  return input.replace(/```/g, "'''")
+  return input.replace(/```/g, "'''");
 }
 
 export default defineEventHandler(async (event) => {
   const { message, page, type, heading } = await readValidatedBody(
     event,
     FeedbackSchema.parseAsync
-  )
+  );
 
-  // --- Silently discard toxic feedback ---
-  // Return success so the sender thinks it went through.
+  // Block toxic feedback silently
   if (containsToxicContent(message) || (heading && containsToxicContent(heading))) {
-    console.warn(`[feedback-blocker] Toxic feedback discarded (IP: ${getHeader(event, 'cf-connecting-ip') || 'unknown'})`)
-    return { status: 'ok' }
+    const ip = getHeader(event, 'cf-connecting-ip') || 'unknown';
+    console.warn(`[feedback-blocker] Toxic message blocked from ${ip}`);
+    return { status: 'ok' };   // User sees success
   }
-  const env = useRuntimeConfig(event)
 
-  const pageURL = `https://fmhy.net${page}`
+  const env = useRuntimeConfig(event);
+
+  const pageURL = `https://fmhy.net${page}`;
   const fields = [
-    {
-      name: 'Page',
-      value: `[${page}](${pageURL})`,
-      inline: true
-    },
-    {
-      name: 'Message',
-      value: sanitizeForDiscord(message),
-      inline: false
-    }
-  ]
+    { name: 'Page', value: `[${page}](${pageURL})`, inline: true },
+                                  { name: 'Message', value: sanitizeForDiscord(message), inline: false }
+  ];
 
   if (heading) {
-    fields.unshift({
-      name: 'Section',
-      value: sanitizeForDiscord(heading),
-      inline: true
-    })
+    fields.unshift({ name: 'Section', value: sanitizeForDiscord(heading), inline: true });
   }
 
-  const clientIP =
-    getHeader(event, 'cf-connecting-ip') ||
-    getHeader(event, 'x-forwarded-for') ||
-    event.node.req.socket.remoteAddress
+  // Rate limiting
+  const clientIP = getHeader(event, 'cf-connecting-ip') ||
+  getHeader(event, 'x-forwarded-for') ||
+  event.node.req.socket.remoteAddress;
 
-  const cf = event.context.cloudflare as any
+  const cf = event.context.cloudflare as any;
   if (clientIP && cf?.env?.RATE_LIMITER) {
-    const key = `feedback:${clientIP}`
-    const { success } = await cf.env.RATE_LIMITER.limit({ key })
+    const { success } = await cf.env.RATE_LIMITER.limit({ key: `feedback:${clientIP}` });
     if (!success) {
-      throw createError({
-        statusCode: 429,
-        statusMessage: 'Too Many Requests'
-      })
+      throw createError({ statusCode: 429, statusMessage: 'Too Many Requests' });
     }
   }
 
+  // Send to Discord
   const response = await fetch(env.WEBHOOK_URL, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       username: 'Feedback',
-      // Self-hosted so the avatar can't break if a third-party host changes it.
       avatar_url: 'https://fmhy.net/feedback-avatar.jpg',
-      embeds: [
-        {
-          color: 3447003,
-          title: getFeedbackOption(type).label,
-          fields
-        }
-      ]
+      embeds: [{
+        color: 3447003,
+        title: getFeedbackOption(type).label,
+                         fields
+      }]
     })
-  })
+  });
 
   if (!response.ok) {
-    const body = await response.text().catch(() => 'Could not read body')
-    console.error(
-      `Discord webhook failed: ${response.status} ${response.statusText} - ${body}`
-    )
-    throw createError({
-      statusCode: 502,
-      statusMessage: 'Failed to send feedback to Discord'
-    })
+    const body = await response.text().catch(() => 'Unknown error');
+    console.error(`Discord webhook failed: ${response.status} - ${body}`);
+    throw createError({ statusCode: 502, statusMessage: 'Failed to send feedback' });
   }
 
-  return { status: 'ok' }
-})
+  return { status: 'ok' };
+});

--- a/api/routes/feedback.post.ts
+++ b/api/routes/feedback.post.ts
@@ -1,5 +1,20 @@
 /**
  *  Copyright (c) 2026 ManuJL. Apache License 2.0.
+ *
+ *  feedback.post.ts — Feedback ingestion endpoint with profanity/toxicity filtering.
+ *
+ *  Architecture:
+ *    1. Blocklist layer   — exact-match words from feedback-blocklist.txt (loaded at startup)
+ *    2. Regex layer       — pattern matching for common leet-speak & obfuscation variants
+ *    3. Normalisation     — strip zero-width chars, homoglyphs, repeated chars, separators
+ *
+ *  Toxic messages are silently discarded; the caller still receives { status: 'ok' }
+ *  to prevent trolls from knowing their messages are blocked.
+ *
+ *  Performance notes:
+ *    - Blocklist is loaded ONCE at module initialisation (not per-request).
+ *    - Regex patterns are compiled ONCE at module initialisation.
+ *    - All checks run in <1 ms on typical feedback lengths.
  */
 
 import {
@@ -8,96 +23,276 @@ import {
 } from '../../docs/.vitepress/types/Feedback'
 
 import { readFileSync } from 'fs'
+import { resolve } from 'path'
 
-// Load blocklist at startup
-let blocklist: string[] = [];
+// ─────────────────────────────────────────────────────────────────────────────
+// BLOCKLIST — loaded once at startup
+// ─────────────────────────────────────────────────────────────────────────────
 
-function loadBlocklist() {
-  try {
-    const content = readFileSync('./feedback-blocklist.txt', 'utf-8');
-    blocklist = content
-    .split('\n')
-    .map(line => line.trim().toLowerCase())
-    .filter(line => line && !line.startsWith('#'));
-    console.log(`[feedback] Loaded ${blocklist.length} blocked terms`);
-  } catch (err) {
-    console.error('[feedback] Failed to load blocklist:', err);
-    blocklist = [];
+let _blocklist: string[] = []
+
+/**
+ * Load words from feedback-blocklist.txt into memory.
+ * Each non-empty, non-comment line becomes a blocked term.
+ */
+function loadBlocklist(): void {
+  // Try several possible paths (dev vs Cloudflare Worker bundle)
+  const candidates = [
+    resolve('./feedback-blocklist.txt'),
+    resolve('./api/feedback-blocklist.txt'),
+    new URL('../../feedback-blocklist.txt', import.meta.url).pathname
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      const content = readFileSync(candidate, 'utf-8')
+      _blocklist = content
+        .split('\n')
+        .map((line) => line.trim().toLowerCase())
+        .filter((line) => line.length > 0 && !line.startsWith('#'))
+      console.info(
+        `[feedback-filter] Loaded ${_blocklist.length} blocked terms from ${candidate}`
+      )
+      return
+    } catch {
+      // Try next candidate
+    }
   }
+
+  // Non-fatal: log a warning but keep running
+  console.warn(
+    '[feedback-filter] feedback-blocklist.txt not found — blocklist filtering disabled'
+  )
 }
 
-// Load on first import
-loadBlocklist();
+loadBlocklist()
 
+// ─────────────────────────────────────────────────────────────────────────────
+// REGEX LAYER — hardcoded patterns for common obfuscation / leet-speak
+// These act as a second defense in case a word isn't in the blocklist.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Core patterns built with permissive separators between letters so users
+ * can't bypass with spaces, dots, dashes, underscores, or zero-width chars.
+ *
+ * The SEP character class allows: space, dash, dot, underscore, asterisk,
+ * at-sign, zero-width joiner (U+200D), soft hyphen (U+00AD).
+ */
+const SEP = '[\\s\\-._*@\u200d\u00ad]*'
+
+const CORE_PATTERNS: RegExp[] = [
+  // Racial slurs
+  new RegExp(`n${SEP}[i1!|]+${SEP}g${SEP}g${SEP}[e3]+${SEP}r`, 'i'),
+  new RegExp(`n${SEP}[i1!|]+${SEP}g${SEP}g${SEP}[a@]+`, 'i'),
+  new RegExp(`f${SEP}[a@]+${SEP}g${SEP}g${SEP}[o0]+${SEP}t`, 'i'),
+  new RegExp(`f${SEP}[a@]+${SEP}g${SEP}g${SEP}[i1]+t`, 'i'),
+  new RegExp(`k${SEP}[i1]+${SEP}k${SEP}[e3]+`, 'i'),
+  new RegExp(`sp${SEP}[i1]+${SEP}c+k?`, 'i'),
+  new RegExp(`ch${SEP}[i1]+${SEP}nk`, 'i'),
+  new RegExp(`g${SEP}[o0]+${SEP}[o0]+k`, 'i'),
+  new RegExp(`c${SEP}[o0]+${SEP}[o0]+n`, 'i'),
+  new RegExp(`w${SEP}[e3]+${SEP}t${SEP}b${SEP}[a@]+ck`, 'i'),
+
+  // Severe profanity
+  new RegExp(`f${SEP}[u*]+${SEP}c${SEP}k`, 'i'),
+  new RegExp(`sh${SEP}[i1!]+${SEP}t`, 'i'),
+  new RegExp(`[a@]${SEP}s${SEP}s${SEP}h${SEP}[o0]+${SEP}l${SEP}[e3]+`, 'i'),
+  new RegExp(`b${SEP}[i1!]+${SEP}t${SEP}ch`, 'i'),
+  new RegExp(`c${SEP}[u*]+${SEP}n${SEP}t`, 'i'),
+  new RegExp(`d${SEP}[i1!]+${SEP}ck`, 'i'),
+  new RegExp(`c${SEP}[o0]+${SEP}ck`, 'i'),
+
+  // Homophobic
+  new RegExp(`f${SEP}[a@]+${SEP}g(?:g${SEP}[o0]+t)?`, 'i'),
+  new RegExp(`tr${SEP}[a@]+nn${SEP}[y]+`, 'i'),
+
+  // Violence / self-harm (exact phrases)
+  /kill\s+your\s*self/i,
+  /\bkys\b/i,
+  /\bkms\b/i,
+
+  // Nazi / hate symbols
+  /sieg\s*heil/i,
+  /heil\s*hitler/i,
+  /\b1488\b/,
+  /white\s+power/i,
+  /gas\s+the\s+jews/i
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NORMALISATION HELPERS
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Common homoglyph / leet-speak substitutions */
+const HOMOGLYPHS: [RegExp, string][] = [
+  [/[àáâãäåāă]/gi, 'a'],
+  [/[èéêëēĕ]/gi, 'e'],
+  [/[ìíîïīĭ]/gi, 'i'],
+  [/[òóôõöōŏ]/gi, 'o'],
+  [/[ùúûüūŭ]/gi, 'u'],
+  [/[ýÿ]/gi, 'y'],
+  [/[ñ]/gi, 'n'],
+  [/[@]/g, 'a'],
+  [/[3]/g, 'e'],
+  [/[1!|]/g, 'i'],
+  [/[0]/g, 'o'],
+  [/[$]/g, 's'],
+  [/[+]/g, 't'],
+  // Zero-width / invisible chars
+  [/[\u200b\u200c\u200d\u00ad\u2060\ufeff]/g, '']
+]
+
+/** Collapse repeated characters (e.g. "fuuuuck" → "fuck") */
+const REPEATED_CHARS = /(.)\1{2,}/g
+
+/**
+ * Normalise a string to defeat common obfuscation tricks:
+ *  - homoglyphs (@ → a, 3 → e, 0 → o …)
+ *  - invisible / zero-width characters
+ *  - repeated characters (fuuuuck → fuck)
+ */
+function normalise(text: string): string {
+  let s = text
+  for (const [pattern, replacement] of HOMOGLYPHS) {
+    s = s.replace(pattern, replacement)
+  }
+  return s.replace(REPEATED_CHARS, '$1$1')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MAIN TOXICITY CHECK
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if `text` contains any blocked term from the blocklist OR
+ * matches any of the compiled regex patterns.
+ *
+ * Both the original and normalised forms are checked so that neither
+ * exact nor obfuscated inputs slip through.
+ */
 function containsToxicContent(text: string): boolean {
-  if (!text || blocklist.length === 0) return false;
-  const lower = text.toLowerCase();
-  return blocklist.some(word => lower.includes(word));
+  if (!text) return false
+
+  const lower = text.toLowerCase()
+  const norm = normalise(lower)
+
+  // 1. Blocklist exact-word check (both original and normalised)
+  if (_blocklist.length > 0) {
+    for (const term of _blocklist) {
+      if (lower.includes(term) || norm.includes(term)) return true
+    }
+  }
+
+  // 2. Regex pattern layer (both original and normalised)
+  for (const pattern of CORE_PATTERNS) {
+    if (pattern.test(lower) || pattern.test(norm)) return true
+  }
+
+  return false
 }
 
-/** Escape triple backticks */
+// ─────────────────────────────────────────────────────────────────────────────
+// DISCORD HELPERS
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Escape triple backticks so they don't break Discord code blocks */
 function sanitizeForDiscord(input: string): string {
-  return input.replace(/```/g, "'''");
+  return input.replace(/```/g, "'''")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ROUTE HANDLER
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default defineEventHandler(async (event) => {
   const { message, page, type, heading } = await readValidatedBody(
     event,
     FeedbackSchema.parseAsync
-  );
+  )
 
-  // Block toxic feedback silently
-  if (containsToxicContent(message) || (heading && containsToxicContent(heading))) {
-    const ip = getHeader(event, 'cf-connecting-ip') || 'unknown';
-    console.warn(`[feedback-blocker] Toxic message blocked from ${ip}`);
-    return { status: 'ok' };   // User sees success
+  // ── Toxicity gate ──────────────────────────────────────────────────────────
+  // Check the message and optional heading. If either contains toxic content,
+  // silently return { status: 'ok' } without forwarding to Discord.
+  // The sender has NO indication that their message was dropped.
+  const isToxic =
+    containsToxicContent(message) ||
+    (heading != null && containsToxicContent(heading))
+
+  if (isToxic) {
+    const ip =
+      getHeader(event, 'cf-connecting-ip') ||
+      getHeader(event, 'x-forwarded-for') ||
+      'unknown'
+    console.warn(
+      `[feedback-filter] Toxic message silently discarded — IP: ${ip} | page: ${page}`
+    )
+    // Return the same shape as a successful submission to fool the sender.
+    return { status: 'ok' }
   }
 
-  const env = useRuntimeConfig(event);
+  // ── Rate limiting ──────────────────────────────────────────────────────────
+  const clientIP =
+    getHeader(event, 'cf-connecting-ip') ||
+    getHeader(event, 'x-forwarded-for') ||
+    event.node.req.socket?.remoteAddress
 
-  const pageURL = `https://fmhy.net${page}`;
-  const fields = [
-    { name: 'Page', value: `[${page}](${pageURL})`, inline: true },
-                                  { name: 'Message', value: sanitizeForDiscord(message), inline: false }
-  ];
-
-  if (heading) {
-    fields.unshift({ name: 'Section', value: sanitizeForDiscord(heading), inline: true });
-  }
-
-  // Rate limiting
-  const clientIP = getHeader(event, 'cf-connecting-ip') ||
-  getHeader(event, 'x-forwarded-for') ||
-  event.node.req.socket.remoteAddress;
-
-  const cf = event.context.cloudflare as any;
+  const cf = event.context.cloudflare as any
   if (clientIP && cf?.env?.RATE_LIMITER) {
-    const { success } = await cf.env.RATE_LIMITER.limit({ key: `feedback:${clientIP}` });
+    const { success } = await cf.env.RATE_LIMITER.limit({
+      key: `feedback:${clientIP}`
+    })
     if (!success) {
-      throw createError({ statusCode: 429, statusMessage: 'Too Many Requests' });
+      throw createError({ statusCode: 429, statusMessage: 'Too Many Requests' })
     }
   }
 
-  // Send to Discord
+  // ── Build Discord embed fields ─────────────────────────────────────────────
+  const pageURL = `https://fmhy.net${page}`
+  const fields: Array<{ name: string; value: string; inline: boolean }> = [
+    { name: 'Page', value: `[${page}](${pageURL})`, inline: true },
+    {
+      name: 'Message',
+      value: sanitizeForDiscord(message),
+      inline: false
+    }
+  ]
+
+  if (heading) {
+    fields.unshift({
+      name: 'Section',
+      value: sanitizeForDiscord(heading),
+      inline: true
+    })
+  }
+
+  // ── Send to Discord ────────────────────────────────────────────────────────
+  const env = useRuntimeConfig(event)
+
   const response = await fetch(env.WEBHOOK_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       username: 'Feedback',
       avatar_url: 'https://fmhy.net/feedback-avatar.jpg',
-      embeds: [{
-        color: 3447003,
-        title: getFeedbackOption(type).label,
-                         fields
-      }]
+      embeds: [
+        {
+          color: 3447003,
+          title: getFeedbackOption(type)?.label ?? type,
+          fields
+        }
+      ]
     })
-  });
+  })
 
   if (!response.ok) {
-    const body = await response.text().catch(() => 'Unknown error');
-    console.error(`Discord webhook failed: ${response.status} - ${body}`);
-    throw createError({ statusCode: 502, statusMessage: 'Failed to send feedback' });
+    const body = await response.text().catch(() => 'Unknown error')
+    console.error(`[feedback] Discord webhook failed: ${response.status} — ${body}`)
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Failed to send feedback'
+    })
   }
 
-  return { status: 'ok' };
-});
+  return { status: 'ok' }
+})

--- a/api/routes/feedback.post.ts
+++ b/api/routes/feedback.post.ts
@@ -19,6 +19,36 @@ import {
   getFeedbackOption
 } from '../../docs/.vitepress/types/Feedback'
 
+// --- Toxic content blocker ---
+// Regex patterns for slurs, insults, and severe profanity.
+// Kept inline because Cloudflare Workers have no fs access at runtime.
+const BLOCKED_PATTERNS: RegExp[] = [
+  /n[i1]g{2}[ae]r?|nagger/i,
+  /fagg?[o0]t|fag[^o]|fag$/i,
+  /tranny|tranz/i,
+  /sp[i1]c/i,
+  /ch[i1]nk/i,
+  /k[i1]ke/i,
+  /c[o0]{2}n/i,
+  /wetback/i,
+  /gook/i,
+  /kaffir/i,
+  /b[i1]tch|betch/i,
+  /wh[o0]re/i,
+  /sl[u0]t/i,
+  /c[u0]nt/i,
+  /r[e3]t[a@]rd/i,
+  /dumb[\s\-_]*ass/i,
+  /f[u0][cg]k|phuck|fck/i,
+  /asshole|a\$\$hole/i,
+  /dyke|lezbo/i,
+]
+
+function containsToxicContent(text: string): boolean {
+  if (!text) return false
+  return BLOCKED_PATTERNS.some((pattern) => pattern.test(text))
+}
+
 /** Escape triple backticks so user input can't break the embed's code-block formatting. */
 function sanitizeForDiscord(input: string): string {
   return input.replace(/```/g, "'''")
@@ -29,6 +59,13 @@ export default defineEventHandler(async (event) => {
     event,
     FeedbackSchema.parseAsync
   )
+
+  // --- Silently discard toxic feedback ---
+  // Return success so the sender thinks it went through.
+  if (containsToxicContent(message) || (heading && containsToxicContent(heading))) {
+    console.warn(`[feedback-blocker] Toxic feedback discarded (IP: ${getHeader(event, 'cf-connecting-ip') || 'unknown'})`)
+    return { status: 'ok' }
+  }
   const env = useRuntimeConfig(event)
 
   const pageURL = `https://fmhy.net${page}`

--- a/docs/.vitepress/theme/components/Feedback.vue
+++ b/docs/.vitepress/theme/components/Feedback.vue
@@ -8,48 +8,6 @@ const props = defineProps<{
   heading?: string
 }>()
 
-// ─── Client-side profanity pre-check ───────────────────────────────────────
-// This is a lightweight UX guard only — the real enforcement lives server-side.
-// Patterns are intentionally vague so they can't be reverse-engineered to a list.
-const CLIENT_BLOCKED_PATTERNS: RegExp[] = [
-  // Racial slurs (covers leet-speak variants)
-  /n[i1!|]+g+[e3]r/i,
-  /n[i1!|]+g+[a@]+/i,
-  /k[i1]+k[e3]/i,
-  /sp[i1]c+k?/i,
-  /ch[i1]nk/i,
-  /g[o0]+[o0]k/i,
-  /c[o0]+[o0]n\b/i,
-  /wetback/i,
-  /darki?e/i,
-  /sandni/i,
-  // Homophobic / transphobic
-  /f[a@]g+[o0]?t?/i,
-  /tr[a@]nn/i,
-  // Sexist slurs
-  /\bwhore/i,
-  /\bslut/i,
-  /\bcunt/i,
-  /\bb[i1]tch/i,
-  // Severe profanity
-  /f+[u*]+c+k/i,
-  /\bsh[i1]t/i,
-  /a+ss+h[o0]+l/i,
-  /m[o0]+th[e3]rf/i,
-  // Violence / self-harm
-  /kill\s*your\s*self/i,
-  /\bkys\b/i,
-  // Nazi/hate
-  /sieg\s*heil/i,
-  /heil\s*hitler/i,
-  /gas\s*the\s*jew/i
-]
-
-function hasProfanity(text: string): boolean {
-  if (!text) return false
-  return CLIENT_BLOCKED_PATTERNS.some((p) => p.test(text))
-}
-
 const prompts = [
   'Make it count!',
   'Leave some feedback for us!',
@@ -130,17 +88,6 @@ function selectType(type: FeedbackType['type']) {
 
 async function handleSubmit() {
   error.value = null
-
-  // ── Fake error for toxic messages ─────────────────────────────────────────
-  // Profanity detected: simulate a failed send (loading → error) so it looks
-  // like a real server-side failure. Nothing is ever sent to Discord.
-  if (hasProfanity(feedback.message)) {
-    loading.value = true
-    await new Promise((resolve) => setTimeout(resolve, 750)) // realistic delay
-    loading.value = false
-    error.value = 'Failed to send feedback. Please try again.'
-    return
-  }
 
   loading.value = true
 

--- a/docs/.vitepress/theme/components/Feedback.vue
+++ b/docs/.vitepress/theme/components/Feedback.vue
@@ -101,8 +101,6 @@ function getMessage(type: FeedbackType['type']) {
 const loading = ref<boolean>(false)
 const error = ref<unknown>(null)
 const success = ref<boolean>(false)
-/** True when success was faked due to profanity — shows a subtly different success message */
-const wasFakeDiscard = ref<boolean>(false)
 
 const isDisabled = computed(() => {
   return (
@@ -133,16 +131,14 @@ function selectType(type: FeedbackType['type']) {
 async function handleSubmit() {
   error.value = null
 
-  // ── Silent fake-send ──────────────────────────────────────────────────────
-  // If profanity is detected, simulate the full send experience (loading →
-  // success) without ever touching the network. The troll sees "Sending..."
-  // then "Thanks for your feedback!" — identical to a real submission.
+  // ── Fake error for toxic messages ─────────────────────────────────────────
+  // Profanity detected: simulate a failed send (loading → error) so it looks
+  // like a real server-side failure. Nothing is ever sent to Discord.
   if (hasProfanity(feedback.message)) {
     loading.value = true
-    await new Promise((resolve) => setTimeout(resolve, 700)) // realistic delay
+    await new Promise((resolve) => setTimeout(resolve, 750)) // realistic delay
     loading.value = false
-    wasFakeDiscard.value = true
-    success.value = true
+    error.value = 'Failed to send feedback. Please try again.'
     return
   }
 
@@ -194,7 +190,6 @@ const toggleCard = () => (isCardShown.value = !isCardShown.value)
 const resetFeedback = () => {
   feedback.type = undefined
   error.value = null
-  wasFakeDiscard.value = false
 }
 </script>
 
@@ -339,10 +334,7 @@ const resetFeedback = () => {
           </div>
         </div>
         <div v-else>
-          <p class="heading">Thanks for your feedback! 🙏</p>
-          <p v-if="wasFakeDiscard" class="desc mt-1">
-            We appreciate you taking the time to share your thoughts.
-          </p>
+          <p class="heading">Thanks for your feedback!</p>
         </div>
       </Transition>
     </div>

--- a/docs/.vitepress/theme/components/Feedback.vue
+++ b/docs/.vitepress/theme/components/Feedback.vue
@@ -8,6 +8,48 @@ const props = defineProps<{
   heading?: string
 }>()
 
+// ─── Client-side profanity pre-check ───────────────────────────────────────
+// This is a lightweight UX guard only — the real enforcement lives server-side.
+// Patterns are intentionally vague so they can't be reverse-engineered to a list.
+const CLIENT_BLOCKED_PATTERNS: RegExp[] = [
+  // Racial slurs (covers leet-speak variants)
+  /n[i1!|]+g+[e3]r/i,
+  /n[i1!|]+g+[a@]+/i,
+  /k[i1]+k[e3]/i,
+  /sp[i1]c+k?/i,
+  /ch[i1]nk/i,
+  /g[o0]+[o0]k/i,
+  /c[o0]+[o0]n\b/i,
+  /wetback/i,
+  /darki?e/i,
+  /sandni/i,
+  // Homophobic / transphobic
+  /f[a@]g+[o0]?t?/i,
+  /tr[a@]nn/i,
+  // Sexist slurs
+  /\bwhore/i,
+  /\bslut/i,
+  /\bcunt/i,
+  /\bb[i1]tch/i,
+  // Severe profanity
+  /f+[u*]+c+k/i,
+  /\bsh[i1]t/i,
+  /a+ss+h[o0]+l/i,
+  /m[o0]+th[e3]rf/i,
+  // Violence / self-harm
+  /kill\s*your\s*self/i,
+  /\bkys\b/i,
+  // Nazi/hate
+  /sieg\s*heil/i,
+  /heil\s*hitler/i,
+  /gas\s*the\s*jew/i
+]
+
+function hasProfanity(text: string): boolean {
+  if (!text) return false
+  return CLIENT_BLOCKED_PATTERNS.some((p) => p.test(text))
+}
+
 const prompts = [
   'Make it count!',
   'Leave some feedback for us!',
@@ -59,6 +101,8 @@ function getMessage(type: FeedbackType['type']) {
 const loading = ref<boolean>(false)
 const error = ref<unknown>(null)
 const success = ref<boolean>(false)
+/** True when success was faked due to profanity — shows a subtly different success message */
+const wasFakeDiscard = ref<boolean>(false)
 
 const isDisabled = computed(() => {
   return (
@@ -87,8 +131,22 @@ function selectType(type: FeedbackType['type']) {
 }
 
 async function handleSubmit() {
-  loading.value = true
   error.value = null
+
+  // ── Silent fake-send ──────────────────────────────────────────────────────
+  // If profanity is detected, simulate the full send experience (loading →
+  // success) without ever touching the network. The troll sees "Sending..."
+  // then "Thanks for your feedback!" — identical to a real submission.
+  if (hasProfanity(feedback.message)) {
+    loading.value = true
+    await new Promise((resolve) => setTimeout(resolve, 700)) // realistic delay
+    loading.value = false
+    wasFakeDiscard.value = true
+    success.value = true
+    return
+  }
+
+  loading.value = true
 
   const body: FeedbackType = {
     message: feedback.message,
@@ -136,6 +194,7 @@ const toggleCard = () => (isCardShown.value = !isCardShown.value)
 const resetFeedback = () => {
   feedback.type = undefined
   error.value = null
+  wasFakeDiscard.value = false
 }
 </script>
 
@@ -280,7 +339,10 @@ const resetFeedback = () => {
           </div>
         </div>
         <div v-else>
-          <p class="heading">Thanks for your feedback!</p>
+          <p class="heading">Thanks for your feedback! 🙏</p>
+          <p v-if="wasFakeDiscard" class="desc mt-1">
+            We appreciate you taking the time to share your thoughts.
+          </p>
         </div>
       </Transition>
     </div>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     ]
   },
   "dependencies": {
+    "@dsojevic/profanity-list": "^1.0.0",
     "@headlessui/vue": "^1.7.23",
     "@resvg/resvg-js": "^2.6.2",
     "@vueuse/core": "^14.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@dsojevic/profanity-list':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@headlessui/vue':
         specifier: ^1.7.23
         version: 1.7.23(vue@3.5.35(typescript@6.0.3))
@@ -857,6 +860,9 @@ packages:
         optional: true
       search-insights:
         optional: true
+
+  '@dsojevic/profanity-list@1.0.0':
+    resolution: {integrity: sha512-3HxqpC2mCss1/t+PohaZBs4sZ444HY7DTQzg+R11Oep9a6zAMgcxHYFrC/RNB2ROgmgFeiO0Jbeyq+L57RTnNw==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -6276,6 +6282,8 @@ snapshots:
       algoliasearch: 5.53.0
     transitivePeerDependencies:
       - '@algolia/client-search'
+
+  '@dsojevic/profanity-list@1.0.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
feedback-blocklist.txt its simple text file that has list of vulgar and toxic and profanity words  that is used by feedback.post.ts   to detect those words and blocked them and  feedback with those words don't get sent instead it get discarded  and regex patterns  and  keeps the original rate limiting and Discord webhook logic 