### PR TITLE
Add FreeGamesOnline to Browser Game Aggregators

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -759,6 +759,7 @@
 * [⁠Flockyard](https://flockyard.pages.dev/) - Browser Game Aggregator
 * [Snokido](https://www.snokido.com/) - Browser Game Aggregator
 * [FreeGames](https://freegames.org/) - Browser Game Aggregator
+* [FreeGamesOnline](https://www.freegamesonline.com/) - Browser Game Aggregator / In-House Original Games
 * [GamezHero](https://www.gamezhero.com/) - Browser Game Aggregator
 * [Web Games](https://webgames.me/) - Browser Game Aggregator
 * [Yandex Games](https://yandex.com/games/) - Browser Game Aggregator


### PR DESCRIPTION
Disclosure: this is my own site.

FreeGamesOnline.com — 450+ free browser games, instant play, no signup/account required. Comparable to the other aggregators in this list (ad-supported via the game provider, no paywalls).

What's different from the other aggregator entries: we also make in-house original games, free to play and free to embed — e.g. [Prove You're Human](https://www.freegamesonline.com/games/prove-youre-human) (absurd-CAPTCHA comedy game) and [Type Sprint](https://www.freegamesonline.com/games/type-sprint) (daily typing race, same words worldwide each day).

Placed alphabetically after FreeGames in the Browser Game Aggregator list. Happy to adjust wording to house style.