### PR TITLE
Add MarkText to Markdown Editors list

### DIFF
--- a/docs/text-tools.md
+++ b/docs/text-tools.md
@@ -464,6 +464,7 @@
 
 * ⭐ **[MarkD](https://markd.it/)** / [GitHub](https://github.com/itzcozi/markd/)
 * ⭐ **[HedgeDoc](https://hedgedoc.org/)**
+* [MarkText](https://www.marktext.me/) / Realtime preview / [Github](https://github.com/marktext/marktext)
 * [⁠Markdown Monster](https://markdownmonster.west-wind.com/) / [GitHub](https://github.com/RickStrahl/MarkdownMonster) 
 * [Zettlr](https://www.zettlr.com/) / [GitHub](https://github.com/Zettlr/Zettlr)
 * [Dillinger](https://dillinger.io/)


### PR DESCRIPTION
MarkText wasn't listed in the markdown editors list.