### PR TITLE
Add QuickImageHub to Online PDF Toolkits

### DIFF
--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -241,6 +241,7 @@
 * [⁠itinypdf](https://itinypdf.com/) - Client-Side
 * [PDFClear](https://www.pdfclear.com/) - Client-Side
 * [DigiPDF](https://digipdf.app/?lang=en_US) - Client-Side
+* [QuickImageHub](https://quickimagehub.com/) - Client-Side Image / PDF Tools
 * [Sejda](https://www.sejda.com/)
 * [ILovePDF](https://www.ilovepdf.com/)
 * [⁠PDRResizer](https://pdfresizer.com/)


### PR DESCRIPTION
QuickImageHub is a free client-side image/PDF toolkit (~85 tools: merge, split, compress, convert, OCR, sign, redact, etc). Files are processed in the browser and never uploaded - no sign-up, no file size or usage limits.

Placed it with the other Client-Side entries in Online PDF Toolkits.

Disclosure: I'm the developer.