### PR TITLE
Add Eovant to Browser Game Aggregators

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -748,6 +748,7 @@
 * ⭐ **[Flash Arch](https://flasharch.com/en)** - Browser Game Aggregator / [Discord](https://discord.com/invite/guQ9Afn)
 * ⭐ **[Kongregate](https://www.kongregate.com/)** - Browser Game Aggregator
 * ⭐ **[Crazy Games](https://www.crazygames.com/)** - Browser Game Aggregator
+* [Eovant](https://eovant.com/) - Browser Game Aggregator
 * ⭐ **[⁠GamesFrog](https://gamesfrog.com/)** - Browser Game Aggregator
 * ⭐ **[Flashpoint](https://flashpointarchive.org/)** - Flash Game Archive App / [Play Online](https://ooooooooo.ooo/browse) / [Discord](https://discord.gg/Z4gGtJvvn8)
 * ⭐ **[Flash Museum](https://flashmuseum.org/)** - Browser Game Aggregator


### PR DESCRIPTION
## Summary
Adds [Eovant](https://eovant.com/) under **Browser Games → Browser Game Aggregators** in `docs/gaming.md`.

## Why this fits
- Free browser / HTML5 game aggregator (instant play, no download)
- English UI, desktop + mobile
- Hand-picked library (sports, racing, arcade, puzzle)

## Notes
- Not paid / trial-only
- Placed next to similar aggregators (after Crazy Games)
- No star — ranking left to maintainers
