### PR TITLE
Add Best Minecraft IDs to Minecraft Tools

### DIFF
--- a/docs/gaming-tools.md
+++ b/docs/gaming-tools.md
@@ -827,6 +827,7 @@
 * [Enchant Order](https://iamcal.github.io/enchant-order/) - Minecraft Enchantment Ordering Tool
 * [Minecraft Tools](https://minecraft.tools/en/) or [GamerGeeks](https://www.gamergeeks.net/) - Minecraft Tools / Calculators
 * [MCStacker](https://mcstacker.net/) / [Discord](https://discord.com/invite/WCb6GNf) - Minecraft Command Generators
+* [Best Minecraft IDs](https://bestminecraftid.com/) - Minecraft ID Database / Command Generators
 * [NBT Studio](https://github.com/tryashtar/nbt-studio/) or [webNBT](https://irath96.github.io/webNBT/) - Minecraft NBT File Editors
 * [MinecraftJSON](https://www.minecraftjson.com/) - Minecraft Tellraw Generator
 


### PR DESCRIPTION
Adds [Best Minecraft IDs](https://bestminecraftid.com/) to the Minecraft Tools section, next to MCStacker (Command Generators).

**What it is:** Free Minecraft Java Edition ID database with 1,500+ searchable items, block/enchantment/effect/entity/biome/sound/particle ID lists, interactive /give command generator, color code chart, and legacy 1.12.2 numerical IDs.

**Why it fits:** Complements existing entries like MCStacker and minecraft.tools by providing a searchable ID reference + command generator in one place. No paywall, actively maintained, static site (fast, no tracking).

**Category:** Minecraft Tools (line ~830, after MCStacker)