### PR TITLE
Add Cinex to non-English streaming services list

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -472,6 +472,7 @@
 * [frembed](https://frembed.lat/) - Movies / TV / Anime / Dub / [Status](https://t.me/+gBSyUOO_3D1mZDZk)
 * [Kordoz](https://www.kordoz.com/) or [Dotriv](https://dotriv.com/) - Movies / TV / Anime
 * [nakastream](https://nakastream.tv/) - Movies / TV / Anime / [Telegram](https://t.me/nakastreamtv) / [Discord](https://discord.gg/SMyrCzWnhV)
+* [Cinex](https://cinex.buzz/) - Movies / TV / Anime / [Status](https://cinex.wiki/)
 * [Paradise lost.666](https://mfp666.blogspot.com/) - Classic French Movies / TV / Music
 * [Film à Revoir](https://filmarevoirnad.blogspot.com/) - Classic French Movies
 * [Ciné-Bis-Art](https://humungus-cinebisart.blogspot.com/) - Movies / Requires Sign-Up


### PR DESCRIPTION
Added Cinex (https://cinex.buzz/) to the list of non-English streaming services, including its status check link (https://cinex.wiki/).