### PR TITLE
Remove Tokuzilla as they appear to have been shut down

### DIFF
--- a/docs/video.md
+++ b/docs/video.md
@@ -267,7 +267,6 @@
 * ⭐ **[Ubu](https://ubu.com/film/)** - Short Films / Avant-Garde
 * ⭐ **[RareFilmm](https://rarefilmm.com/)** - Rare Movies
 * ⭐ **[JP-Films](https://jp-films.com/)** - Japanese Movies / TV
-* ⭐ **[Tokuzilla](https://tokuzilla.net/)** - Tokuzilla Movies / Shows
 * ⭐ **[GizmoPlex](https://www.gizmoplex.com/mst3k)** - MST3K Movies
 * ⭐ **[RiffTrax Twitch](https://www.twitch.tv/rifftrax)** or [RiffTrax Pluto](https://pluto.tv/live-tv/rifftrax) - RiffTrax Live Streams
 * [⁠Interactive Player](https://github.com/Eveep23/Interactive-Player) - Interactive Content Player / Emulator


### PR DESCRIPTION
Both their main site and their backups have been down for over a week. Members of the tokusatsu community are speculating this to be part of a broader crackdown on tokusatsu streaming, as several other tokusatsu streaming sites were also taken down over the past few weeks.