### PR TITLE
Add Free Image Merger (image-tools)

### DIFF
--- a/docs/image-tools.md
+++ b/docs/image-tools.md
@@ -104,6 +104,7 @@
 * [InColor](https://www.myheritage.com/incolor) - B&W Image Colorization / Requires Sign-Up
 * [⁠Dual Shades](https://dual-shades.anmolagrawal.dev/) - Generate B&W Images w/ Colorized Subjects
 * [PhotoJoiner](https://www.photojoiner.com/) or [⁠Collaigo](https://www.collaigo.com/) / [Discord](https://discord.gg/WbVXpRkWZv) (chrome) - Collage Makers / Editors
+* [Free Image Merger](https://freeimagemerger.com/) - Merge Images Side by Side / Grids / Collages
 * [⁠shabzefilters](https://shabzefilters.netlify.app/) - ASCII, Dot, Braille, Block, Line, etc
 * [VHS-Engine](https://vhs-engine.netlify.app/) - VHS Effect Editor ⁠
 * [AIDraw](https://ai-draw.tokyo/en/) or [⁠FiniteCurve](https://www.finitecurve.com/) - Turn Photos into Line Art


### PR DESCRIPTION
Adds [Free Image Merger](https://freeimagemerger.com/) to the Image Effects section, next to the existing collage makers (PhotoJoiner / Collaigo).

- Merge 2–20 images horizontally, vertically, in a grid, or on a freestyle canvas
- 100% free: no watermark, no signup, no limits
- Fully client-side (HTML5 Canvas) — images are never uploaded, works offline once loaded
- Input PNG/JPG/WebP/GIF/AVIF/BMP, export PNG/JPG/WebP with quality slider

One line added, nothing else changed.