### PR TITLE
Add Wavio (audio players)

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -797,6 +797,7 @@
 * [LedFx](https://docs.ledfx.app/en/stable/) - LED Music Sync / Windows / [Discord](https://discord.gg/xyyHEquZKQ) / [GitHub](https://github.com/ledfx/ledfx)
 * [RockBox](https://www.rockbox.org/) - Custom Player for Audio Devices / [Wiki](https://www.rockbox.org/wiki/) / [Themes](https://themes.rockbox.org/)
 * [VinylEngine](https://www.vinylengine.com/) - Record Player / Vinyl Info
+* [Wavio](https://wavio-app.verce.app) - Navidrome / Jellyfin / Opensubsonic / Local library for Android [GitHub](https://github.com/Joel-Mercier/wavio)
 
 ***
 


### PR DESCRIPTION
Hi I'm the maintainer of Wavio a free and open source music streaming app for Android compatible with Navidrome, Jellyfin and Opensubsonic/Subsonic servers as well as a local library. You can find more infos and a full feature list here https://github.com/Joel-Mercier/wavio

I would like to add the app to the audio players recommendations on the FMHY website.

Happy to provide more info if needed