### PR TITLE
Add PDFKing to File Tools → Online PDF Toolkits

### DIFF
--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -239,6 +239,7 @@
 
 * ⭐ **[BentoPDF](https://bentopdf.com/)** or [File PDF](https://filepdf.net/) - Client-Side / [GitHub](https://github.com/alam00000/bentopdf)
 * ⭐ **[⁠ihatepdf](https://www.ihatepdf.cv/)** - Client-Side
+* [⁠PDFKing](https://pdfking.app/) - Online PDF Toolkit
 * [PDFCraft](https://pdfcraft.devtoolcafe.com/) - Client-Side / [GitHub](https://github.com/PDFCraftTool/pdfcraft)
 * [BreezePDF](https://breezepdf.com/) - Client-Side
 * [⁠itinypdf](https://itinypdf.com/) - Client-Side


### PR DESCRIPTION
## Summary

This PR adds PDFKing to the **Online PDF Toolkits** section.

## About PDFKing

PDFKing is a free online PDF toolkit that provides common PDF utilities, including:

- Merge PDF
- Split PDF
- Compress PDF
- Organize PDF
- Rotate PDF
- Extract & Remove Pages
- JPG ↔ PDF conversion
- PDF ↔ JPG/PNG conversion
- Watermark
- Protect & Unlock PDF
- Crop PDF
- Repair PDF
- Compare PDF
- Redact PDF
- Fill & Sign PDF

The service is free to use without requiring an account for basic functionality.

## Proposed Entry

```markdown
- [⁠PDFKing](https://pdfking.app/) - Online PDF Toolkit