### PR TITLE
Update Video Tools (Streaming) and add LuffyFiles to File Hosting

### DIFF
--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -412,7 +412,7 @@
 * [⁠PolyUploader](https://polyuploader.vercel.app/) / [GitHub](https://github.com/spel987/PolyUploader) or [Z-o-o-m](https://z-o-o-m.eu/) - Multi-Host Upload Desktop Apps
 * [Limited Upload Hosts](https://rentry.org/xc48kg) - More Hosts / 1GB or Below
 * [⁠Pearcrypt](https://pearcrypt.lol/) - File Link Containers / [Discord](https://discord.com/invite/QrrryWKA6X)
-
+* [LuffyFiles](https://luffyfiles.com/) - Unlimited Storage / 5 GB / 30 Days (Auto-deletes after 30 days with no downloads) / No signup
 ***
 
 ## ▷ Cloud Storage

--- a/docs/video-tools.md
+++ b/docs/video-tools.md
@@ -67,6 +67,7 @@
 * [webmshare](https://webmshare.com/) - WebM & GIF Hosting / 20MB / Forever
 * [Videy](https://videy.co/) - 100MB / MP4 Only
 * [⁠SpectrShare](https://spectrshare.com/) - P2P Video Streaming / Temp Files
+* [LuffyFiles](https://luffyfiles.com/) - 5 GB / 30 Days (Auto-deletes after 30 days of inactivity)
 
 ***
 


### PR DESCRIPTION
# Changes

* Updated the **Video Tools** section for streaming.
* Added **LuffyFiles** to the **File Hosting** section.

## LuffyFiles

* Max file size: **5 GB**
* File expiry: **30 days** (auto-deletes after **30 days with no downloads**)
* No signup required