### PR TITLE
Update file-tools.md - add: autofetch.de

### DIFF
--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -39,6 +39,7 @@
 * [⁠Surge](https://github.com/surge-downloader/surge) - TUI Download Manager / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/surge/) / Windows, macOS, Linux
 * [DownThemAll](https://www.downthemall.org/) - Download Management Extension / [Firefox](https://addons.mozilla.org/addon/downthemall/) / [Chrome](https://chrome.google.com/webstore/detail/downthemall/nljkibfhlpcnanjgbnlnbjecgicbjkge) / [GitHub](https://github.com/downthemall/downthemall)
 * [HTTP Downloader](https://erickutcher.github.io/) - Download Manager for HTTP / FTP / SFTP / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/http-downloader/) / [Chrome](https://github.com/erickutcher/httpdownloader/releases/download/CE_v1.0.2.8/HTTP_Downloader_Chrome_Extension.crx) / Windows / [GitHub](https://github.com/erickutcher/httpdownloader)
+* [autofetch](https://autofetch.de/en/) - Client-/Server-Solution for download automation from several sources incl. IRC (basic usage always free)
 
 ***
 

--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -39,7 +39,7 @@
 * [⁠Surge](https://github.com/surge-downloader/surge) - TUI Download Manager / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/surge/) / Windows, macOS, Linux
 * [DownThemAll](https://www.downthemall.org/) - Download Management Extension / [Firefox](https://addons.mozilla.org/addon/downthemall/) / [Chrome](https://chrome.google.com/webstore/detail/downthemall/nljkibfhlpcnanjgbnlnbjecgicbjkge) / [GitHub](https://github.com/downthemall/downthemall)
 * [HTTP Downloader](https://erickutcher.github.io/) - Download Manager for HTTP / FTP / SFTP / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/http-downloader/) / [Chrome](https://github.com/erickutcher/httpdownloader/releases/download/CE_v1.0.2.8/HTTP_Downloader_Chrome_Extension.crx) / Windows / [GitHub](https://github.com/erickutcher/httpdownloader)
-* [autofetch](https://autofetch.de/en/) - Client-/Server-Solution for download automation from several sources incl. IRC (basic usage always free)
+* [autofetch](https://autofetch.de/en/) - Client-/Server-Solution for download automation from several sources incl. IRC (basic usage always free) / Windows, macOS, Linux
 
 ***
 

--- a/docs/file-tools.md
+++ b/docs/file-tools.md
@@ -39,7 +39,7 @@
 * [⁠Surge](https://github.com/surge-downloader/surge) - TUI Download Manager / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/surge/) / Windows, macOS, Linux
 * [DownThemAll](https://www.downthemall.org/) - Download Management Extension / [Firefox](https://addons.mozilla.org/addon/downthemall/) / [Chrome](https://chrome.google.com/webstore/detail/downthemall/nljkibfhlpcnanjgbnlnbjecgicbjkge) / [GitHub](https://github.com/downthemall/downthemall)
 * [HTTP Downloader](https://erickutcher.github.io/) - Download Manager for HTTP / FTP / SFTP / [Firefox](https://addons.mozilla.org/en-US/firefox/addon/http-downloader/) / [Chrome](https://github.com/erickutcher/httpdownloader/releases/download/CE_v1.0.2.8/HTTP_Downloader_Chrome_Extension.crx) / Windows / [GitHub](https://github.com/erickutcher/httpdownloader)
-* [autofetch](https://autofetch.de/en/) - Client-/Server-Solution for download automation from several sources incl. IRC (basic usage always free) / Windows, macOS, Linux
+* [autofetch](https://autofetch.de/en/) - Web-managed download automation with local clients / Media libraries, feeds, release sources & IRC/XDCC / Free basic plan / Open-source client / Windows, macOS, Linux
 
 ***
 


### PR DESCRIPTION
Disclosure: I am the developer and operator of autofetch.

I placed it under Download Managers because it seemed like the closest existing section, but it is more accurately described as download automation. The web service monitors configured sources and creates matching jobs, while a local client downloads the files directly to the user’s device.

Please feel free to move it if another section is a better fit.