### PR TITLE
Add Multiplayer Games to Party / Multiplayer

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -869,6 +869,7 @@
 * [Bloob.io](https://bloob.io/) - Multiple Games
 * [Yucata](https://www.yucata.de/en/) - Multiple Games
 * [Foony](https://foony.com/) - Multiple Games
+* [Multiplayer Games](https://multiplayergames.app/) - Multiple Games
 * [Pixoguess](https://pixoguess.io/) - Guess Pixelated Images / [Discord](https://discord.gg/Rbu8uGCyM6)
 * [Tensor Trust](https://tensortrust.ai/) - AI Prompting Multiplayer Skill Game
 * [AI Bingo](https://ai-bingo.lipsumar.io/) - AI Art Guessing Games


### PR DESCRIPTION
## Summary

Adds [Multiplayer Games](https://multiplayergames.app/) to the **Party / Multiplayer** section under Browser Games.

Free classic 2-player browser games — local pass-and-play, vs CPU, or online with a friend. No download, no account required.

## Entry

```
* [Multiplayer Games](https://multiplayergames.app/) - Multiple Games
```

Placed alongside other multi-game hubs (Bloob.io, Yucata, Foony), matching their short description style.

## Disclosure

I'm affiliated with this site. Happy to adjust wording or placement if needed.

Made with [Cursor](https://cursor.com)