### PR TITLE
Add Deep Brown Noise to Ambient / Relaxation

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -190,6 +190,7 @@
 * [ChillOuts](http://www.chillouts.com/) - Meditation Aid
 * [You are Listening To LA](https://youarelistening.to/) - Ambient City Sounds & Live LAPD Police Radio
 * [TheWhiteNoiseMachine](https://thewhitenoisemachine.com/) - White Noise Generator
+* [Deep Brown Noise](https://deepbrownnoise.com/sounds/) - Brown / White / Pink / Green Noise Player
 
 ***
 


### PR DESCRIPTION
Adds **Deep Brown Noise** to `Audio` → **▷ Ambient / Relaxation** (right after TheWhiteNoiseMachine).

- https://deepbrownnoise.com/sounds/
- A free, in-browser noise player: brown, white, pink and green noise plus nature sounds (rain, thunderstorm, campfire, waterfall…). Loops in the browser, no account or download needed.

Not already in the wiki (searched `deepbrownnoise` / `brown noise`).