### PR TITLE
Remove Anime-Base entry from non-english.md

### DIFF
--- a/docs/non-english.md
+++ b/docs/non-english.md
@@ -583,7 +583,6 @@
 * [zdf](https://www.zdf.de/) - Public Broadcast
 * [Burning Series](https://burningseries.ac/), [2](https://burningseries.cx/) - TV / Dub / 720p
 * [Anime-Loads](https://www.anime-loads.org/) - Anime / Dub / 1080p
-* [Anime-Base](https://anime-base.net/) - Anime / Dub / 1080p / [Improvement Extension](https://berni-92.github.io/anime-base-autoplayer/) / [Discord](https://discord.gg/sj6mDujvMD)
 * [Aniworld](https://aniworld.to) - Anime / Sub / Dub / 720p / [Status](https://aniworld.domains/) / [Discord](https://discord.com/invite/xTkw6292Uj)
 * [⁠Fireani](https://fireani.me/app) - Anime Android App
 * [⁠TOGGO](https://www.toggo.de/) - Cartoons


### PR DESCRIPTION
As the Website Developer of Anime-Base.net, I can completely confirm that as of today, Anime-Base.net has closed and won't return.