### PR TITLE
Allow starred and indexes toggles to work together

### DIFF
--- a/docs/.vitepress/theme/components/ToggleIndexes.vue
+++ b/docs/.vitepress/theme/components/ToggleIndexes.vue
@@ -2,13 +2,10 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import Switch from './Switch.vue'
 
-const isDisabled = ref(false)
 const isOn = ref(false)
 
 const syncState = () => {
-  const root = document.documentElement
-  isDisabled.value = root.classList.contains('starred-only')
-  isOn.value = root.classList.contains('indexes-only')
+  isOn.value = document.documentElement.classList.contains('indexes-only')
 }
 
 let observer: MutationObserver | undefined
@@ -28,46 +25,22 @@ onMounted(syncState)
 onBeforeUnmount(() => observer?.disconnect())
 
 const toggleIndexes = (value: boolean) => {
-  if (isDisabled.value) {
-    isOn.value = document.documentElement.classList.contains('indexes-only')
-    return
-  }
-
   const root = document.documentElement
-  const enabling = value
-  const wasStarred = root.classList.contains('starred-only')
-
-  root.classList.toggle('indexes-only', enabling)
-
-  if (enabling) {
-    root.dataset.starredWasOn = wasStarred ? 'true' : 'false'
-
-    if (wasStarred) {
-      root.classList.remove('starred-only')
-    }
-  } else {
-    if (root.dataset.starredWasOn === 'true') {
-      root.classList.add('starred-only')
-    }
-
-    delete root.dataset.starredWasOn
-  }
-
-  isOn.value = enabling
+  root.classList.toggle('indexes-only', value)
+  isOn.value = value
 }
 </script>
 
 <template>
-  <Switch
-    v-model="isOn"
-    :disabled="isDisabled"
-    :class="{ disabled: isDisabled }"
-    @update:model-value="toggleIndexes"
-  />
+  <Switch v-model="isOn" @update:model-value="toggleIndexes" />
 </template>
 
 <style>
-.indexes-only .vp-doc li:not(.index) {
+.indexes-only:not(.starred-only) .vp-doc li:not(.index) {
+  display: none;
+}
+
+.starred-only.indexes-only .vp-doc li:not(.starred):not(.index) {
   display: none;
 }
 </style>

--- a/docs/.vitepress/theme/components/ToggleStarred.vue
+++ b/docs/.vitepress/theme/components/ToggleStarred.vue
@@ -2,13 +2,10 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import Switch from './Switch.vue'
 
-const isDisabled = ref(false)
 const isOn = ref(false)
 
 const syncState = () => {
-  const root = document.documentElement
-  isDisabled.value = root.classList.contains('indexes-only')
-  isOn.value = root.classList.contains('starred-only')
+  isOn.value = document.documentElement.classList.contains('starred-only')
 }
 
 let observer: MutationObserver | undefined
@@ -28,29 +25,18 @@ onMounted(syncState)
 onBeforeUnmount(() => observer?.disconnect())
 
 const toggleStarred = (value: boolean) => {
-  if (isDisabled.value) {
-    isOn.value = document.documentElement.classList.contains('starred-only')
-    return
-  }
-
   const root = document.documentElement
   root.classList.toggle('starred-only', value)
-  root.dataset.starredWasOn = value ? 'true' : 'false'
   isOn.value = value
 }
 </script>
 
 <template>
-  <Switch
-    v-model="isOn"
-    :disabled="isDisabled"
-    :class="{ disabled: isDisabled }"
-    @update:model-value="toggleStarred"
-  />
+  <Switch v-model="isOn" @update:model-value="toggleStarred" />
 </template>
 
 <style>
-.starred-only .vp-doc li:not(.starred) {
+.starred-only:not(.indexes-only) .vp-doc li:not(.starred) {
   display: none;
 }
 </style>


### PR DESCRIPTION
Closes #5929

Removes the mutual exclusion between Toggle Starred and Toggle Indexes so both switches can be enabled at the same time.

- Drop the disable/restore logic (including the `starredWasOn` dataset dance) from `ToggleStarred.vue` and `ToggleIndexes.vue`
- Individual mode rules now only apply when the other toggle is off (`:not(.indexes-only)` / `:not(.starred-only)`)
- New combined rule hides list items that are neither `.starred` nor `.index` when both toggles are active, so starred and index entries render together

The `.vp-doc` scope is kept so the TOC is never hidden.