### PR TITLE
Add Oats to AI Tools

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -382,6 +382,7 @@
 * [⁠Agent Reach](https://github.com/Panniantong/Agent-Reach) - Connect AI Agents to Popular Internet Platforms
 * [MassiveMark](https://www.bibcit.com/en/massivemark) - Convert LLM Chats to DOCX / [Discord](https://discord.gg/fPtQAQYmqq)
 * [screenpipe](https://screenpi.pe/) - AI Screen Recorder / No Sign-Up / [Discord](https://discord.gg/dU9EBuw7Uq) / [GitHub](https://github.com/mediar-ai/screenpipe)
+* [Oats](https://ariso.ai/oats) - Local Meeting Recorder / Transcriber / AI Notes / Mac Only / No Sign-Up / [GitHub](https://github.com/ariso-ai/oats)
 * [ChatGPT Exporter](https://greasyfork.org/en/scripts/456055) - Export Chats / [GitHub](https://github.com/pionxzh/chatgpt-exporter)
 * [GPThemes](https://github.com/itsmartashub/GPThemes) - ChatGPT Themes
 * [⁠WhichLLM](https://github.com/Andyyyy64/whichllm) - LLM Performance Comparison Tool


### PR DESCRIPTION
Adds [Oats](https://ariso.ai/oats) to the AI Tools section of `docs/ai.md`.

Oats is a free, open-source macOS app that records and transcribes meetings locally on-device — no cloud uploads, no meeting bots, no sign-up. It generates AI notes, extracts action items, and keeps a searchable meeting library. Source: https://github.com/ariso-ai/oats

Disclosure: I work on Oats at Ariso.