### PR TITLE
feat(educational): add country profile references (Factbook alternatives)

### DIFF
--- a/docs/educational.md
+++ b/docs/educational.md
@@ -698,6 +698,7 @@
 * [Data Commons](https://datacommons.org/) or [Engaging Data](https://engaging-data.com/) - World Data Visualizations
 * [EverySecond](https://everysecond.io/) - Visualize Per Second World Data
 * [If It Were My Home](https://www.ifitweremyhome.com/), [GlobalEdge](https://globaledge.msu.edu/) or [MyLifeElsewhere](https://www.mylifeelsewhere.com/) - Country Data Comparisons
+* [Databook](https://databook.dataint.net/en/) or [OpenFactBook](https://openfactbook.org/) - Country Profiles / World Factbook Alternatives
 * [NationsEncyclopedia](https://www.nationsencyclopedia.com/) or [⁠CityPopulation](https://citypopulation.de/) - Location / Population Data
 * [City Data](https://www.city-data.com/) - US City Data
 * [Rulers.org](https://rulers.org/) or [EveryPolitician](https://everypolitician.org/) / [GitHub](https://github.com/opensanctions/everypolitician.org) - World Heads Of State & Government Databases

--- a/docs/educational.md
+++ b/docs/educational.md
@@ -699,6 +699,7 @@
 * [EverySecond](https://everysecond.io/) - Visualize Per Second World Data
 * [If It Were My Home](https://www.ifitweremyhome.com/), [GlobalEdge](https://globaledge.msu.edu/) or [MyLifeElsewhere](https://www.mylifeelsewhere.com/) - Country Data Comparisons
 * [Databook](https://databook.dataint.net/en/) or [OpenFactBook](https://openfactbook.org/) - Country Profiles / World Factbook Alternatives
+* [Logibook](https://logibook.dataint.net/en) - Trade & Logistics Reference / HS Codes / Dangerous Goods / Ports / Airports
 * [NationsEncyclopedia](https://www.nationsencyclopedia.com/) or [⁠CityPopulation](https://citypopulation.de/) - Location / Population Data
 * [City Data](https://www.city-data.com/) - US City Data
 * [Rulers.org](https://rulers.org/) or [EveryPolitician](https://everypolitician.org/) / [GitHub](https://github.com/opensanctions/everypolitician.org) - World Heads Of State & Government Databases


### PR DESCRIPTION
**Adds one line under World Data & Statistics.**

The CIA World Factbook was shut down in February 2026, so the country-profile
slot that a lot of people used is currently empty in the wiki. Two free
alternatives:

- **[Databook](https://databook.dataint.net/en/)** — ~250 countries, 242
  indicators across 15 sections (geography, population, economy, health,
  education, environment, governance, infrastructure). Every figure names its
  source and indicator code on the page; 41 of the indicators carry the
  Factbook's own fields forward. 25 languages, no signup.
- **[OpenFactBook](https://openfactbook.org/)** — community-maintained Factbook
  successor, 260+ countries, side-by-side country comparison. Not mine, added
  because it belongs on the same line.

Both are free with no account, no trial and no paywall.

**Disclosure:** I built and run Databook. It's ad-funded, which is how it stays
free — same model as Worldometer already on that line. Nothing to buy and
nothing to sign up for. If you'd rather list only OpenFactBook, that's a fair
call and the line still works.
